### PR TITLE
Add doc header

### DIFF
--- a/.storybook/scss/doc-header.scss
+++ b/.storybook/scss/doc-header.scss
@@ -13,11 +13,16 @@ $docs-content-margin: $docs-title-height - $content-margin-top;
   align-items: flex-end;
   height: $docs-title-height;
   background-color: $teal;
+  border-bottom-right-radius: 60px;
 
   div {
     width: 100%;
     max-width: $content-max-width;
     margin: 0 auto;
+  }
+
+  &--with-tab {
+    border-radius: 0;
   }
 }
 
@@ -32,10 +37,10 @@ $docs-content-margin: $docs-title-height - $content-margin-top;
 .docs-content {
   padding-top: 40px;
   margin-top: $docs-content-margin !important;
-}
 
-.docs-content--with-tab {
-  padding: 0;
+  .docs-title--with-tab +& {
+    padding-top: 0;
+  }
 }
 
 .simple-tab-wrapper {
@@ -44,7 +49,7 @@ $docs-content-margin: $docs-title-height - $content-margin-top;
   left: 0;
   height: $simple-tab-item-height;
   background-color: $teal-60;
-  border-bottom-right-radius: 80px;
+  border-bottom-right-radius: 60px;
 }
 
 // Tabs used for documentation. Should be later replaced by our top bar or tabs.

--- a/stories/Animation.stories.mdx
+++ b/stories/Animation.stories.mdx
@@ -1,4 +1,16 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Atoms | Animation" />
+<Meta title="Atoms | Motion" />
+
+<div class="docs-title">
+  <div>
+    <h1 class="docs-title__text">Motion</h1>
+  </div>
+</div>
+
+<div class="docs-content">
+
+Work in progress
+
+</div>

--- a/stories/Colors.stories.mdx
+++ b/stories/Colors.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Atoms | Colors" />
+<Meta title="Base | Colors" />
 
 <div class="docs-title docs-title--with-tab">
   <div>

--- a/stories/Colors.stories.mdx
+++ b/stories/Colors.stories.mdx
@@ -3,13 +3,13 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 <Meta title="Atoms | Colors" />
 
-<div class="docs-title">
+<div class="docs-title docs-title--with-tab">
   <div>
     <h1 class="docs-title__text">Colors</h1>
   </div>
 </div>
 
-<div class="docs-content docs-content--with-tab">
+<div class="docs-content">
   <div class="simple-tab-wrapper"></div>
   <input class="simple-tab" type="radio" name="colors-tab" id="tab1" checked/>
   <label for="tab1">Design</label>

--- a/stories/IconAndBadge.stories.mdx
+++ b/stories/IconAndBadge.stories.mdx
@@ -6,7 +6,13 @@ import Badge from '../labsystem/src/Badge';
 
 <Meta title="Components | Icons & Badges" component={Icon} />
 
-# Icons & Badges
+<div class="docs-title">
+  <div>
+    <h1 class="docs-title__text">Icons & Badges</h1>
+  </div>
+</div>
+
+<div class="docs-content">
 
 The `Icon` and `Badge` components have similar behavior.
 
@@ -204,3 +210,5 @@ Here's the list of props based on the component's prop types definitions.
 
 ### Badge
 <Props of={Badge} />
+
+</div>

--- a/stories/Motions.stories.mdx
+++ b/stories/Motions.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Atoms | Motion" />
+<Meta title="Base | Motion" />
 
 <div class="docs-title">
   <div>

--- a/stories/Spacing.stories.mdx
+++ b/stories/Spacing.stories.mdx
@@ -3,189 +3,194 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 <Meta title="Atoms | Spacing" />
 
-<div>
-  <h1>Spacing</h1>
-  <p>This token can be applied to <code>margin</code> or <code>padding</code> properties to both vertical and horizontal edges.</p>
+<div class="docs-title">
+  <div>
+    <h1 class="docs-title__text">Spacing</h1>
+  </div>
 </div>
 
-<div>
-  <h2>Scales</h2>
-  <div class="columns">
-    <div class="column">
-      <p>On spacing, we have <code>$spacing</code> and <code>$layout</code> tokens, the first for general spacing within components, and the other for layout spacing. They are built to complement components and type system and to assemble elements within a page.</p>
+<div class="docs-content">
+  <p>This token can be applied to <code>margin</code> or <code>padding</code> properties to both vertical and horizontal edges.</p>
+
+  <div>
+    <h2>Scales</h2>
+    <div class="columns">
+      <div class="column">
+        <p>On spacing, we have <code>$spacing</code> and <code>$layout</code> tokens, the first for general spacing within components, and the other for layout spacing. They are built to complement components and type system and to assemble elements within a page.</p>
+      </div>
+      <div class="column">
+        <p>The two scales have certain overlapping values that serve two different roles, so be mindful when picking a spacing token.</p>
+      </div>
     </div>
-    <div class="column">
-      <p>The two scales have certain overlapping values that serve two different roles, so be mindful when picking a spacing token.</p>
-    </div>
-  </div>
-  <div class="columns">
-    <div class="column">
-      <h3>Spacing scale</h3>
-      <p>Used for refinement, specifically used within a component (i.e. the space between a label and a text input).</p>
-      <table>
-        <tr>
-          <th>Token</th>
-          <th>rem</th>
-          <th>px</th>
-          <th>Example</th>
-        </tr>
-        <tr>
-          <td><code>$spacing-01</code></td>
-          <td>0.25</td>
-          <td>4</td>
-          <td><img src="docs/tokens-spacing/01-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-02</code></td>
-          <td>0.5</td>
-          <td>8</td>
-          <td><img src="docs/tokens-spacing/02-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-03</code></td>
-          <td>0.75</td>
-          <td>12</td>
-          <td><img src="docs/tokens-spacing/03-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-04</code></td>
-          <td>1</td>
-          <td>16</td>
-          <td><img src="docs/tokens-spacing/04-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-05</code></td>
-          <td>1.25</td>
-          <td>20</td>
-          <td><img src="docs/tokens-spacing/05-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-06</code></td>
-          <td>1.5</td>
-          <td>24</td>
-          <td><img src="docs/tokens-spacing/06-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-07</code></td>
-          <td>2</td>
-          <td>32</td>
-          <td><img src="docs/tokens-spacing/07-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-08</code></td>
-          <td>2.5</td>
-          <td>40</td>
-          <td><img src="docs/tokens-spacing/08-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-09</code></td>
-          <td>3.25</td>
-          <td>52</td>
-          <td><img src="docs/tokens-spacing/09-spacing.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$spacing-10</code></td>
-          <td>3.75</td>
-          <td>60</td>
-          <td><img src="docs/tokens-spacing/10-spacing.png" /></td>
-        </tr>
-      </table>
-    </div>
-    <div class="column">
-      <h3>Layout scale</h3>
-      <p>Used for positioning components on a page (i.e., the space between a text field and a selector).</p>
-      <table>
-        <tr>
-          <th>Token</th>
-          <th>rem</th>
-          <th>px</th>
-          <th>Example</th>
-        </tr>
-        <tr>
-          <td><code>$layout-01</code></td>
-          <td>0.75</td>
-          <td>12</td>
-          <td><img src="docs/tokens-spacing/01-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-02</code></td>
-          <td>1</td>
-          <td>16</td>
-          <td><img src="docs/tokens-spacing/02-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-03</code></td>
-          <td>1.25</td>
-          <td>20</td>
-          <td><img src="docs/tokens-spacing/03-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-04</code></td>
-          <td>1.5</td>
-          <td>24</td>
-          <td><img src="docs/tokens-spacing/04-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-05</code></td>
-          <td>2</td>
-          <td>32</td>
-          <td><img src="docs/tokens-spacing/05-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-06</code></td>
-          <td>2.5</td>
-          <td>40</td>
-          <td><img src="docs/tokens-spacing/06-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-07</code></td>
-          <td>2.75</td>
-          <td>44</td>
-          <td><img src="docs/tokens-spacing/07-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-08</code></td>
-          <td>3.25</td>
-          <td>52</td>
-          <td><img src="docs/tokens-spacing/08-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-09</code></td>
-          <td>4</td>
-          <td>64</td>
-          <td><img src="docs/tokens-spacing/09-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-10</code></td>
-          <td>4.5</td>
-          <td>72</td>
-          <td><img src="docs/tokens-spacing/10-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-11</code></td>
-          <td>5.75</td>
-          <td>92</td>
-          <td><img src="docs/tokens-spacing/11-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-12</code></td>
-          <td>6.25</td>
-          <td>100</td>
-          <td><img src="docs/tokens-spacing/12-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-13</code></td>
-          <td>7.75</td>
-          <td>124</td>
-          <td><img src="docs/tokens-spacing/13-layout.png" /></td>
-        </tr>
-        <tr>
-          <td><code>$layout-14</code></td>
-          <td>8.75</td>
-          <td>140</td>
-          <td><img src="docs/tokens-spacing/14-layout.png" /></td>
-        </tr>
-      </table>
+    <div class="columns">
+      <div class="column">
+        <h3>Spacing scale</h3>
+        <p>Used for refinement, specifically used within a component (i.e. the space between a label and a text input).</p>
+        <table>
+          <tr>
+            <th>Token</th>
+            <th>rem</th>
+            <th>px</th>
+            <th>Example</th>
+          </tr>
+          <tr>
+            <td><code>$spacing-01</code></td>
+            <td>0.25</td>
+            <td>4</td>
+            <td><img src="docs/tokens-spacing/01-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-02</code></td>
+            <td>0.5</td>
+            <td>8</td>
+            <td><img src="docs/tokens-spacing/02-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-03</code></td>
+            <td>0.75</td>
+            <td>12</td>
+            <td><img src="docs/tokens-spacing/03-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-04</code></td>
+            <td>1</td>
+            <td>16</td>
+            <td><img src="docs/tokens-spacing/04-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-05</code></td>
+            <td>1.25</td>
+            <td>20</td>
+            <td><img src="docs/tokens-spacing/05-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-06</code></td>
+            <td>1.5</td>
+            <td>24</td>
+            <td><img src="docs/tokens-spacing/06-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-07</code></td>
+            <td>2</td>
+            <td>32</td>
+            <td><img src="docs/tokens-spacing/07-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-08</code></td>
+            <td>2.5</td>
+            <td>40</td>
+            <td><img src="docs/tokens-spacing/08-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-09</code></td>
+            <td>3.25</td>
+            <td>52</td>
+            <td><img src="docs/tokens-spacing/09-spacing.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$spacing-10</code></td>
+            <td>3.75</td>
+            <td>60</td>
+            <td><img src="docs/tokens-spacing/10-spacing.png" /></td>
+          </tr>
+        </table>
+      </div>
+      <div class="column">
+        <h3>Layout scale</h3>
+        <p>Used for positioning components on a page (i.e., the space between a text field and a selector).</p>
+        <table>
+          <tr>
+            <th>Token</th>
+            <th>rem</th>
+            <th>px</th>
+            <th>Example</th>
+          </tr>
+          <tr>
+            <td><code>$layout-01</code></td>
+            <td>0.75</td>
+            <td>12</td>
+            <td><img src="docs/tokens-spacing/01-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-02</code></td>
+            <td>1</td>
+            <td>16</td>
+            <td><img src="docs/tokens-spacing/02-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-03</code></td>
+            <td>1.25</td>
+            <td>20</td>
+            <td><img src="docs/tokens-spacing/03-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-04</code></td>
+            <td>1.5</td>
+            <td>24</td>
+            <td><img src="docs/tokens-spacing/04-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-05</code></td>
+            <td>2</td>
+            <td>32</td>
+            <td><img src="docs/tokens-spacing/05-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-06</code></td>
+            <td>2.5</td>
+            <td>40</td>
+            <td><img src="docs/tokens-spacing/06-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-07</code></td>
+            <td>2.75</td>
+            <td>44</td>
+            <td><img src="docs/tokens-spacing/07-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-08</code></td>
+            <td>3.25</td>
+            <td>52</td>
+            <td><img src="docs/tokens-spacing/08-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-09</code></td>
+            <td>4</td>
+            <td>64</td>
+            <td><img src="docs/tokens-spacing/09-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-10</code></td>
+            <td>4.5</td>
+            <td>72</td>
+            <td><img src="docs/tokens-spacing/10-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-11</code></td>
+            <td>5.75</td>
+            <td>92</td>
+            <td><img src="docs/tokens-spacing/11-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-12</code></td>
+            <td>6.25</td>
+            <td>100</td>
+            <td><img src="docs/tokens-spacing/12-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-13</code></td>
+            <td>7.75</td>
+            <td>124</td>
+            <td><img src="docs/tokens-spacing/13-layout.png" /></td>
+          </tr>
+          <tr>
+            <td><code>$layout-14</code></td>
+            <td>8.75</td>
+            <td>140</td>
+            <td><img src="docs/tokens-spacing/14-layout.png" /></td>
+          </tr>
+        </table>
+      </div>
     </div>
   </div>
 </div>

--- a/stories/Spacing.stories.mdx
+++ b/stories/Spacing.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Atoms | Spacing" />
+<Meta title="Base | Spacing" />
 
 <div class="docs-title">
   <div>

--- a/stories/Toggle.stories.mdx
+++ b/stories/Toggle.stories.mdx
@@ -5,7 +5,13 @@ import Toggle from '../labsystem/src/Toggle';
 
 <Meta title="Components | Toggle" component={Toggle} />
 
-# Toggle
+<div class="docs-title">
+  <div>
+    <h1 class="docs-title__text">Toggle</h1>
+  </div>
+</div>
+
+<div class="docs-content">
 
 The `Toggle` component might receive up to five inputs as props, where the `color` and `name` parameters are the only required ones.
 - `name`: should be an unique identifier and works as the `id` of the `input` tag within the component; it's also an important accessibility tool
@@ -54,3 +60,5 @@ Togge can be disabled and, at the same time receive, a `defaultValue`:
 Here's the list of props based on the component's prop types definitions.
 ### Toggle
 <Props of={Toggle} />
+
+</div>

--- a/stories/Typography.stories.mdx
+++ b/stories/Typography.stories.mdx
@@ -3,13 +3,13 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 <Meta title="Atoms | Typography" />
 
-<div class="docs-title">
+<div class="docs-title docs-title--with-tab">
   <div>
     <h1 class="docs-title__text">Typography</h1>
   </div>
 </div>
 
-<div class="docs-content docs-content--with-tab">
+<div class="docs-content">
   <div class="simple-tab-wrapper"></div>
   <input class="simple-tab" type="radio" name="type-tab" id="tab1" checked/>
   <label for="tab1">Overview</label>

--- a/stories/Typography.stories.mdx
+++ b/stories/Typography.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Atoms | Typography" />
+<Meta title="Base | Typography" />
 
 <div class="docs-title docs-title--with-tab">
   <div>


### PR DESCRIPTION
- Adds doc-header to doc pages that didn't have before
- Adds `border-bottom-right-radius` on doc-header even when tab isn't present
- Rename section "atoms" to "base"
- Rename "animations" to "motion"
