### PR TITLE
Fix storybook styles

### DIFF
--- a/.storybook/corujaElements.json
+++ b/.storybook/corujaElements.json
@@ -1,3 +1,10 @@
 [
-  { "cssInJsSelector": ".css-8x22z7", "customClassName": "example" }
+  { "cssInJsSelector": ".css-g90fw7", "customClassName": "simplebar-content__text" },
+  { "cssInJsSelector": ".css-zrsa9l", "customClassName": "sidebar__more-actions-button" },
+  { "cssInJsSelector": ".css-10xy9do", "customClassName": "sidebar__dropdown-chevron" },
+  { "cssInJsSelector": ".css-5kfycg", "customClassName": "sidebar__dropdown-container" },
+  { "cssInJsSelector": ".css-qab6xu", "customClassName": "sidebar__dropdown-item" },
+  { "cssInJsSelector": ".css-w5ik8", "customClassName": "sidebar__dropdown-text" },
+  { "cssInJsSelector": ".css-8w7sok", "customClassName": "sidebar__dropdown-item-icon" },
+  { "cssInJsSelector": ".css-1g2a4s1", "customClassName": "sidebar__dropdown-item-shortcut" }
 ]

--- a/.storybook/theme/main.scss
+++ b/.storybook/theme/main.scss
@@ -94,7 +94,7 @@ input:focus + svg {
     font-family: "freight-sans-pro" !important;
     font-size: 16px !important;
 
-    .css-g90fw7 {
+    .simplebar-content__text {
       font-weight: 600 !important;
     }
   }
@@ -106,18 +106,18 @@ The classes below didn't have a defined name.
 */
 
 //button
-.css-zrsa9l {
+.sidebar__more-actions-button {
   color: #007B7D !important;
   box-shadow: #007B7D 0 0 0 1px inset !important;
 }
 
 //dropdown chevron
-.css-10xy9do {
+.sidebar__dropdown-chevron {
   border-bottom-color: #009EA1 !important;
 }
 
 //dropdown container
-.css-5kfycg {
+.sidebar__dropdown-container {
   max-height: none !important;
   border-radius: 4px !important;
   padding: 8px 0;
@@ -125,7 +125,7 @@ The classes below didn't have a defined name.
 }
 
 //dropdown item
-.css-qab6xu {
+.sidebar__dropdown-item {
   background: #009EA1 !important;
   font-family: "freight-sans-pro" !important;
   font-size: 14px !important;
@@ -133,17 +133,17 @@ The classes below didn't have a defined name.
 }
 
 //dropdown item text
-.css-w5ik8{
+.sidebar__dropdown-text {
   font-weight: 500 !important;
   color: white !important;
 }
 
 //dropdown item icon
-.css-8w7sok {
+.sidebar__dropdown-item-icon {
   color: white !important;
 }
 
 //dropdown item shortcut
-.css-1g2a4s1 {
+.sidebar__dropdown-item-shortcut {
   color: white !important;
 }

--- a/.storybook/theme/main.scss
+++ b/.storybook/theme/main.scss
@@ -10,10 +10,6 @@
 }
 
 //sidebar
-.sidebar-header{
-  padding: 28px !important;
-}
-
 .sidebar-subheading {
   color: #007B7D !important;
   font-family: "freight-sans-pro" !important;
@@ -91,7 +87,7 @@ input:focus + svg {
     right: 12px !important;
     background: none !important;
   }
-  
+
   //filter result text//
   form ~ div {
     color: #007B7D !important;
@@ -110,7 +106,7 @@ The classes below didn't have a defined name.
 */
 
 //button
-.css-1k6p28m {
+.css-zrsa9l {
   color: #007B7D !important;
   box-shadow: #007B7D 0 0 0 1px inset !important;
 }
@@ -121,7 +117,7 @@ The classes below didn't have a defined name.
 }
 
 //dropdown container
-.css-8ra542 {
+.css-5kfycg {
   max-height: none !important;
   border-radius: 4px !important;
   padding: 8px 0;

--- a/stories/ChangeLog.stories.mdx
+++ b/stories/ChangeLog.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Getting started | Changelog" />
+<Meta title="Getting started/Changelog" />
 
 <div class="docs-title">
   <div>

--- a/stories/Colors.stories.mdx
+++ b/stories/Colors.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Base | Colors" />
+<Meta title="Base/Colors" />
 
 <div class="docs-title docs-title--with-tab">
   <div>

--- a/stories/IconAndBadge.stories.mdx
+++ b/stories/IconAndBadge.stories.mdx
@@ -4,7 +4,7 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import Icon from '../labsystem/src/Icon';
 import Badge from '../labsystem/src/Badge';
 
-<Meta title="Components | Icons & Badges" component={Icon} />
+<Meta title="Components/Icons & Badges" component={Icon} />
 
 <div class="docs-title">
   <div>

--- a/stories/Motions.stories.mdx
+++ b/stories/Motions.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Base | Motion" />
+<Meta title="Base/Motion" />
 
 <div class="docs-title">
   <div>

--- a/stories/Spacing.stories.mdx
+++ b/stories/Spacing.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Base | Spacing" />
+<Meta title="Base/Spacing" />
 
 <div class="docs-title">
   <div>

--- a/stories/Toggle.stories.mdx
+++ b/stories/Toggle.stories.mdx
@@ -3,7 +3,7 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
 import Toggle from '../labsystem/src/Toggle';
 
-<Meta title="Components | Toggle" component={Toggle} />
+<Meta title="Components/Toggle" component={Toggle} />
 
 <div class="docs-title">
   <div>

--- a/stories/Typography.stories.mdx
+++ b/stories/Typography.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react';
 import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 
-<Meta title="Base | Typography" />
+<Meta title="Base/Typography" />
 
 <div class="docs-title docs-title--with-tab">
   <div>


### PR DESCRIPTION
Storybook updates change the name of its autogenerated css classes.
As we override some of these classes to implement the Labcodes theme in the Sidebar, the style gets broken.
![image](https://user-images.githubusercontent.com/29437811/88075567-5c52b300-cb4f-11ea-952f-3a374ed5324e.png)

This PR will update the css classes names to fix the styles, and fill the `corujaElements.json` file, which should make this process easier the next times.
![image](https://user-images.githubusercontent.com/29437811/88075707-8ad08e00-cb4f-11ea-9ef6-27675a124251.png)


The sidebar dropdown menu icons still could be improved, as can be seen below.
![image](https://user-images.githubusercontent.com/29437811/88075444-2dd4d800-cb4f-11ea-9acd-25322d942c70.png)
