### PR TITLE
Update Text Input components according to QA findings

### DIFF
--- a/labsystem/src/Input/AbstractTextInput.js
+++ b/labsystem/src/Input/AbstractTextInput.js
@@ -125,21 +125,29 @@ export default class AbstractTextInput extends React.Component {
   };
 
   handleOnChange = (e) => {
-    const { onChange, isValid, customErrorMsg } = this.props;
+    const { onChange, isValid, customErrorMsg, required } = this.props;
     const inputElement = e.target;
     const inputElementValue = inputElement.value;
     const inputElementIsValid = inputElement.validity.valid;
 
+    // First we reset the custom validity
+    inputElement.setCustomValidity("");
+
     if (!isUndefined(onChange)) {
       onChange(e);
     }
-    this.setState({ localValue: inputElementValue });
-    if (isUndefined(isValid)) {
-      this.setState({ localIsValid: inputElementIsValid });
-    } else if (!isValid) {
-      inputElement.setCustomValidity(customErrorMsg);
-      this.setState({ localIsValid: isValid });
-    }
+
+    // Then we set the state with the new value
+    this.setState({ localValue: inputElementValue }, () => {
+      if (isUndefined(isValid) || (isValid && required)) {
+        // Finally, if the user doesn't force the 'isValid', we use browser's validation from the input
+        this.setState({ localIsValid: inputElementIsValid });
+      } else if (!isValid) {
+        // We only set the customErrorMsg again if the input is forced invalid
+        inputElement.setCustomValidity(customErrorMsg);
+        this.setState({ localIsValid: isValid });
+      }
+    });
   };
 
   render() {

--- a/labsystem/src/Input/AbstractTextInput.js
+++ b/labsystem/src/Input/AbstractTextInput.js
@@ -54,7 +54,7 @@ export default class AbstractTextInput extends React.Component {
       );
     }
     this.state = {
-      localValue: value || defaultValue,
+      localValue: value || defaultValue || "",
       localIsValid: !isUndefined(isValid) ? isValid : true,
     };
   }

--- a/labsystem/src/Input/AbstractTextInput.test.js
+++ b/labsystem/src/Input/AbstractTextInput.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from "react";
 import { mount } from "enzyme";
 import renderer from "react-test-renderer";

--- a/labsystem/src/Input/AbstractTextInput.test.js
+++ b/labsystem/src/Input/AbstractTextInput.test.js
@@ -118,6 +118,11 @@ describe("AbstractTextInput", () => {
     component.update();
 
     expect(component.find(".lab-input--invalid")).toHaveLength(1);
+
+    component.setProps({ value: "valid@value.com" });
+    component.update();
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
   });
 
   it("shows help text", async () => {
@@ -183,10 +188,54 @@ describe("AbstractTextInput", () => {
       .find("input")
       .at(0)
       .simulate("change", {
-        target: { value: "My new value", validity: { valid: true } },
+        target: {
+          value: "My new value",
+          validity: { valid: true },
+          setCustomValidity: jest.fn(),
+        },
       });
 
     expect(inputElement.render().attr("value")).toBe("My new value");
+  });
+
+  it("sets input as invalid if it is required and is not filled, even if isValid is passed by props as true", async () => {
+    const component = mount(
+      <AbstractTextInput
+        id="testInput"
+        label="Test Input"
+        name="testName"
+        isValid
+        required
+      />
+    );
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+
+    component
+      .find("input")
+      .at(0)
+      .simulate("change", {
+        target: {
+          value: "My new value",
+          validity: { valid: true },
+          setCustomValidity: jest.fn(),
+        },
+      });
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+
+    component
+      .find("input")
+      .at(0)
+      .simulate("change", {
+        target: {
+          value: "",
+          validity: { valid: false },
+          setCustomValidity: jest.fn(),
+        },
+      });
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(1);
   });
 
   it("renders prefix when it is passed by props", async () => {

--- a/labsystem/src/Input/EmailInput.js
+++ b/labsystem/src/Input/EmailInput.js
@@ -16,7 +16,6 @@ export default class EmailInput extends React.Component {
     helpMessage: PropTypes.string,
     prefix: PropTypes.string,
     suffix: PropTypes.string,
-    isValid: PropTypes.bool,
     customErrorMsg: PropTypes.string,
     onChange: PropTypes.func,
     onIconClick: PropTypes.func,
@@ -32,7 +31,6 @@ export default class EmailInput extends React.Component {
     helpMessage: undefined,
     prefix: undefined,
     suffix: undefined,
-    isValid: undefined,
     customErrorMsg: undefined,
     onChange: undefined,
     onIconClick: undefined,
@@ -50,7 +48,6 @@ export default class EmailInput extends React.Component {
       helpMessage,
       prefix,
       suffix,
-      isValid,
       customErrorMsg,
       onChange,
       onIconClick,
@@ -70,7 +67,6 @@ export default class EmailInput extends React.Component {
         helpMessage={helpMessage}
         prefix={prefix}
         suffix={suffix}
-        isValid={isValid}
         customErrorMsg={customErrorMsg}
         onChange={onChange}
         onIconClick={onIconClick}

--- a/labsystem/src/Input/EmailInput.test.js
+++ b/labsystem/src/Input/EmailInput.test.js
@@ -67,18 +67,6 @@ describe("EmailInput", () => {
     expect(inputElement.render().attr("value")).toBe("default value");
   });
 
-  it("sets state with isValid if it is passed by props", async () => {
-    const component = mount(
-      <EmailInput
-        id="testInput"
-        label="Test Input"
-        defaultValue="default value"
-        isValid={false}
-      />
-    );
-    expect(component.find(".lab-input--invalid")).toHaveLength(1);
-  });
-
   it("sets localIsValid to false if defaultValue is invalid", async () => {
     const component = mount(
       <EmailInput

--- a/labsystem/src/Input/EmailInput.test.js
+++ b/labsystem/src/Input/EmailInput.test.js
@@ -170,7 +170,11 @@ describe("EmailInput", () => {
       .find("input")
       .at(0)
       .simulate("change", {
-        target: { value: "My new value", validity: { valid: true } },
+        target: {
+          value: "My new value",
+          validity: { valid: true },
+          setCustomValidity: jest.fn(),
+        },
       });
 
     expect(inputElement.render().attr("value")).toBe("My new value");

--- a/labsystem/src/Input/PasswordInput.test.js
+++ b/labsystem/src/Input/PasswordInput.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from "react";
 import { mount } from "enzyme";
 import renderer from "react-test-renderer";
@@ -105,6 +106,11 @@ describe("PasswordInput", () => {
     component.update();
 
     expect(component.find(".lab-input--invalid")).toHaveLength(1);
+
+    component.setProps({ value: "valid@value.com" });
+    component.update();
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
   });
 
   it("shows help text", async () => {
@@ -177,6 +183,46 @@ describe("PasswordInput", () => {
       });
 
     expect(inputElement.render().attr("value")).toBe("My new value");
+  });
+
+  it("sets input as invalid if it is required and is not filled, even if isValid is passed by props as true", async () => {
+    const component = mount(
+      <PasswordInput
+        id="testInput"
+        label="Test Input"
+        name="testName"
+        isValid
+        required
+      />
+    );
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+
+    component
+      .find("input")
+      .at(0)
+      .simulate("change", {
+        target: {
+          value: "My new value",
+          validity: { valid: true },
+          setCustomValidity: jest.fn(),
+        },
+      });
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+
+    component
+      .find("input")
+      .at(0)
+      .simulate("change", {
+        target: {
+          value: "",
+          validity: { valid: false },
+          setCustomValidity: jest.fn(),
+        },
+      });
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(1);
   });
 
   it("renders prefix when it is passed by props", async () => {

--- a/labsystem/src/Input/PasswordInput.test.js
+++ b/labsystem/src/Input/PasswordInput.test.js
@@ -169,7 +169,11 @@ describe("PasswordInput", () => {
       .find("input")
       .at(0)
       .simulate("change", {
-        target: { value: "My new value", validity: { valid: true } },
+        target: {
+          value: "My new value",
+          validity: { valid: true },
+          setCustomValidity: jest.fn(),
+        },
       });
 
     expect(inputElement.render().attr("value")).toBe("My new value");

--- a/labsystem/src/Input/TextInput.test.js
+++ b/labsystem/src/Input/TextInput.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import React from "react";
 import { mount } from "enzyme";
 import renderer from "react-test-renderer";
@@ -5,15 +6,277 @@ import renderer from "react-test-renderer";
 import TextInput from "./TextInput";
 
 describe("TextInput", () => {
-  it("renders with base props AbstractTextInput with type text", async () => {
+  const originalWarn = console.warn;
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
+  it("renders with base props", async () => {
     const renderedComponent = renderer
       .create(<TextInput id="testInput" label="Test Input" />)
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
-  it("renders AbstractTextInput with type=text", async () => {
+  it("renders as type=text", async () => {
     const component = mount(<TextInput id="testInput" label="Test Input" />);
     expect(component.find("input[type='text']")).toHaveLength(1);
+  });
+
+  it("raises console.warn and sets state with value when passing value and defaultValue by props at the same time", async () => {
+    console.warn = jest.fn();
+
+    const component = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        defaultValue="default value"
+        value="test value"
+      />
+    );
+
+    expect(console.warn).toBeCalled();
+    const inputElement = component.find("input");
+    expect(inputElement.render().attr("value")).toBe("test value");
+  });
+
+  it("sets state with value if it is passed by props", async () => {
+    const component = mount(
+      <TextInput id="testInput" label="Test Input" value="test value" />
+    );
+
+    const inputElement = component.find("input");
+    expect(inputElement.render().attr("value")).toBe("test value");
+  });
+
+  it("sets state with defaultValue if it is passed by props and value is not passed by props", async () => {
+    const component = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        defaultValue="default value"
+      />
+    );
+    const inputElement = component.find("input");
+    expect(inputElement.render().attr("value")).toBe("default value");
+  });
+
+  it("sets state with isValid if it is passed by props", async () => {
+    const component = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        defaultValue="default value"
+        isValid={false}
+      />
+    );
+    expect(component.find(".lab-input--invalid")).toHaveLength(1);
+  });
+
+  it("sets localIsValid to true if value is valid and change it if value validity changes", async () => {
+    const component = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        value="testvalue@g.com"
+        required
+      />
+    );
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+
+    component.setProps({ value: "" });
+    component.update();
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(1);
+
+    component.setProps({ value: "valid@value.com" });
+    component.update();
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+  });
+
+  it("shows help text", async () => {
+    const component = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        value="testvalue@g.com"
+        helpMessage="help message"
+        required
+      />
+    );
+
+    expect(component.find(".lab-input__message--required").text()).toBe(
+      "help message"
+    );
+
+    component.setProps({ value: "" });
+    component.update();
+
+    expect(component.find(".lab-input__message--error").text()).toBe(
+      "help message"
+    );
+  });
+
+  it("shows custom error message when input is invalid", async () => {
+    const component = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        value="test"
+        customErrorMsg="error message"
+        required
+      />
+    );
+
+    expect(component.find(".lab-input__message--error")).toHaveLength(0);
+
+    component.setProps({ value: "" });
+    component.update();
+
+    expect(component.find(".lab-input__message--error").text()).toBe(
+      "error message"
+    );
+  });
+
+  it("changes localValue state when input changes", async () => {
+    const component = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        name="testName"
+        value="truthy value"
+        onChange={() => {}}
+      />
+    );
+
+    const inputElement = component.find("input");
+    expect(inputElement.render().attr("value")).toBe("truthy value");
+
+    component
+      .find("input")
+      .at(0)
+      .simulate("change", {
+        target: {
+          value: "My new value",
+          validity: { valid: true },
+          setCustomValidity: jest.fn(),
+        },
+      });
+
+    expect(inputElement.render().attr("value")).toBe("My new value");
+  });
+
+  it("sets input as invalid if it is required and is not filled, even if isValid is passed by props as true", async () => {
+    const component = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        name="testName"
+        isValid
+        required
+      />
+    );
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+
+    component
+      .find("input")
+      .at(0)
+      .simulate("change", {
+        target: {
+          value: "My new value",
+          validity: { valid: true },
+          setCustomValidity: jest.fn(),
+        },
+      });
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+
+    component
+      .find("input")
+      .at(0)
+      .simulate("change", {
+        target: {
+          value: "",
+          validity: { valid: false },
+          setCustomValidity: jest.fn(),
+        },
+      });
+
+    expect(component.find(".lab-input--invalid")).toHaveLength(1);
+  });
+
+  it("renders prefix when it is passed by props", async () => {
+    const renderedComponent = renderer
+      .create(<TextInput id="testInput" label="Test Input" prefix="R$" />)
+      .toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+
+    const mountedComponent = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        name="testName"
+        prefix="R$"
+      />
+    );
+
+    expect(mountedComponent.find("span.lab-input__prefix")).toHaveLength(2);
+  });
+
+  it("renders suffix when it is passed by props", async () => {
+    const renderedComponent = renderer
+      .create(<TextInput id="testInput" label="Test Input" suffix=".com" />)
+      .toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+
+    const mountedComponent = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        name="testName"
+        suffix=".com"
+      />
+    );
+
+    expect(mountedComponent.find("div.lab-input__suffix")).toHaveLength(1);
+  });
+
+  it("renders icon when it is passed by props", async () => {
+    const renderedComponent = renderer
+      .create(<TextInput id="testInput" label="Test Input" icon="star" />)
+      .toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+
+    const mountedComponent = mount(
+      <TextInput
+        id="testInput"
+        label="Test Input"
+        name="testName"
+        icon="star"
+      />
+    );
+
+    expect(mountedComponent.find("span.lab-icon")).toHaveLength(1);
+  });
+
+  it("renders required icon when it is passed by props", async () => {
+    const renderedComponent = renderer
+      .create(<TextInput id="testInput" label="Test Input" icon="star" />)
+      .toJSON();
+
+    expect(renderedComponent).toMatchSnapshot();
+
+    const mountedComponent = mount(
+      <TextInput id="testInput" label="Test Input" name="testName" required />
+    );
+
+    expect(mountedComponent.find("span.lab-input__required-icon")).toHaveLength(
+      1
+    );
   });
 });

--- a/labsystem/src/Input/__snapshots__/AbstractTextInput.test.js.snap
+++ b/labsystem/src/Input/__snapshots__/AbstractTextInput.test.js.snap
@@ -11,6 +11,7 @@ exports[`AbstractTextInput renders icon when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="text"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -51,6 +52,7 @@ exports[`AbstractTextInput renders prefix when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="text"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -91,6 +93,7 @@ exports[`AbstractTextInput renders required icon when it is passed by props 1`] 
     onChange={[Function]}
     placeholder=" "
     type="text"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -131,6 +134,7 @@ exports[`AbstractTextInput renders suffix when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="text"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -167,6 +171,7 @@ exports[`AbstractTextInput renders with base props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="text"
+    value=""
   />
   <div
     className="lab-input__borders"

--- a/labsystem/src/Input/__snapshots__/EmailInput.test.js.snap
+++ b/labsystem/src/Input/__snapshots__/EmailInput.test.js.snap
@@ -11,6 +11,7 @@ exports[`EmailInput renders icon when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="email"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -51,6 +52,7 @@ exports[`EmailInput renders prefix when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="email"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -91,6 +93,7 @@ exports[`EmailInput renders required icon when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="email"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -131,6 +134,7 @@ exports[`EmailInput renders suffix when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="email"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -167,6 +171,7 @@ exports[`EmailInput renders with base props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="email"
+    value=""
   />
   <div
     className="lab-input__borders"

--- a/labsystem/src/Input/__snapshots__/PasswordInput.test.js.snap
+++ b/labsystem/src/Input/__snapshots__/PasswordInput.test.js.snap
@@ -11,6 +11,7 @@ exports[`PasswordInput renders icon when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="password"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -52,6 +53,7 @@ exports[`PasswordInput renders prefix when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="password"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -101,6 +103,7 @@ exports[`PasswordInput renders required icon when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="password"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -142,6 +145,7 @@ exports[`PasswordInput renders suffix when it is passed by props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="password"
+    value=""
   />
   <div
     className="lab-input__borders"
@@ -187,6 +191,7 @@ exports[`PasswordInput renders with base props 1`] = `
     onChange={[Function]}
     placeholder=" "
     type="password"
+    value=""
   />
   <div
     className="lab-input__borders"

--- a/labsystem/src/Input/__snapshots__/TextInput.test.js.snap
+++ b/labsystem/src/Input/__snapshots__/TextInput.test.js.snap
@@ -1,6 +1,166 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextInput renders with base props AbstractTextInput with type text 1`] = `
+exports[`TextInput renders icon when it is passed by props 1`] = `
+<div
+  className="lab-input "
+>
+  <input
+    autoComplete="off"
+    className="lab-input__field "
+    id="testInput"
+    onChange={[Function]}
+    placeholder=" "
+    type="text"
+    value=""
+  />
+  <div
+    className="lab-input__borders"
+  />
+  
+  
+  <div
+    className="lab-input__label-wrapper"
+  >
+    
+    <label
+      className="lab-input__label"
+      htmlFor="testInput"
+    >
+      Test Input
+    </label>
+  </div>
+  <button
+    className="lab-input__icon lab-input__icon--disabled"
+    type="button"
+  >
+    <span
+      className="lab-icon lab-icon--star lab-icon--mineral70"
+    />
+  </button>
+  
+</div>
+`;
+
+exports[`TextInput renders prefix when it is passed by props 1`] = `
+<div
+  className="lab-input "
+>
+  <input
+    autoComplete="off"
+    className="lab-input__field lab-input__field--prefixed "
+    id="testInput"
+    onChange={[Function]}
+    placeholder=" "
+    type="text"
+    value=""
+  />
+  <div
+    className="lab-input__borders"
+  />
+  <span
+    className="lab-input__prefix"
+  >
+    R$
+  </span>
+  
+  <div
+    className="lab-input__label-wrapper"
+  >
+    <span
+      className="lab-input__prefix"
+    >
+      R$
+    </span>
+    <label
+      className="lab-input__label"
+      htmlFor="testInput"
+    >
+      Test Input
+    </label>
+  </div>
+  
+</div>
+`;
+
+exports[`TextInput renders required icon when it is passed by props 1`] = `
+<div
+  className="lab-input "
+>
+  <input
+    autoComplete="off"
+    className="lab-input__field "
+    id="testInput"
+    onChange={[Function]}
+    placeholder=" "
+    type="text"
+    value=""
+  />
+  <div
+    className="lab-input__borders"
+  />
+  
+  
+  <div
+    className="lab-input__label-wrapper"
+  >
+    
+    <label
+      className="lab-input__label"
+      htmlFor="testInput"
+    >
+      Test Input
+    </label>
+  </div>
+  <button
+    className="lab-input__icon lab-input__icon--disabled"
+    type="button"
+  >
+    <span
+      className="lab-icon lab-icon--star lab-icon--mineral70"
+    />
+  </button>
+  
+</div>
+`;
+
+exports[`TextInput renders suffix when it is passed by props 1`] = `
+<div
+  className="lab-input "
+>
+  <input
+    autoComplete="off"
+    className="lab-input__field lab-input__field--suffixed "
+    id="testInput"
+    onChange={[Function]}
+    placeholder=" "
+    type="text"
+    value=""
+  />
+  <div
+    className="lab-input__borders"
+  />
+  
+  <div
+    className="lab-input__suffix"
+  >
+    .com
+  </div>
+  <div
+    className="lab-input__label-wrapper"
+  >
+    
+    <label
+      className="lab-input__label"
+      htmlFor="testInput"
+    >
+      Test Input
+    </label>
+  </div>
+  
+</div>
+`;
+
+exports[`TextInput renders with base props 1`] = `
 <div
   className="lab-input "
 >

--- a/labsystem/src/Input/__snapshots__/TextInput.test.js.snap
+++ b/labsystem/src/Input/__snapshots__/TextInput.test.js.snap
@@ -11,6 +11,7 @@ exports[`TextInput renders with base props AbstractTextInput with type text 1`] 
     onChange={[Function]}
     placeholder=" "
     type="text"
+    value=""
   />
   <div
     className="lab-input__borders"

--- a/playgrounds/InputPlayground.js
+++ b/playgrounds/InputPlayground.js
@@ -127,7 +127,6 @@ export default class InputPlayground extends React.Component {
             suffix={suffix}
             customErrorMsg={customErrorMsg}
             required={required}
-            isValid={isValid}
             onChange={this.handlePropChangeText}
             {...(disabled ? { disabled } : undefined)}
           />

--- a/stories/TextInput.stories.mdx
+++ b/stories/TextInput.stories.mdx
@@ -75,7 +75,7 @@ It’s a standard text input. Can be used for enter a id, phone number, street a
         <h6>Trailing icon</h6>
         <TextInput className="lab-input__field--icon" id="id2" label="Label" icon="eye-opened" iconColor="mineral70" />
         <h6>Error</h6>
-        <TextInput type="email" id="error" label="Name" defaultValue="Teste" customErrorMsg="Error message" />
+        <EmailInput id="error" label="Name" defaultValue="Teste" customErrorMsg="Error message" />
       </div>
     </Fragment>
   </Story>


### PR DESCRIPTION
- Remove prop `isValid` from EmailInput, so that email validation is made by the browser
- Fix validation issue when `customErrorMsg` is passed and `isValid` is not passed by props (before fixing, when passing customErrorMsg, the input validity would not change to valid after being invalid even if it should)
- Add missing tests