### PR TITLE
Narrow sidebar adjusts

### DIFF
--- a/.storybook/scss/doc-narrow-sidebar.scss
+++ b/.storybook/scss/doc-narrow-sidebar.scss
@@ -198,6 +198,7 @@
   }
 }
 
+// Overlay that appers only on mobile.
 .lab-narrow__overlay {
   content: "";
   position: fixed;
@@ -222,13 +223,13 @@
   }
 }
 
-// Topbar that apperson only on mobile.
+// Topbar that appers only on mobile.
 // It holds the button to open the sidebar on mobile.
 .lab-narrow-sidebar__mobile-topbar {
   position:fixed;
   right: 0;
   top: 0;
-  background-color: $teal-60;
+  background-color: map-get($narrow-sidebar-theme, "60");
   width: 100%;
   height: 76px;
   border-bottom: 1px solid transparent;
@@ -238,3 +239,26 @@
   }
 }
 
+.lab-narrow-sidebar__mobile-button {
+  display: flex;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  margin: 18px 0 18px 12px;
+  background-color: transparent;
+  border: $border-01 transparent;
+  border-radius: $radius-02;
+
+  &:focus {
+    border-color: $white-50;
+    outline: none;
+  }
+
+  &:active {
+    background-color: $white-75;
+
+    .lab-icon {
+      background-color: map-get($narrow-sidebar-theme, "70");
+    }
+  }
+}

--- a/.storybook/scss/doc-narrow-sidebar.scss
+++ b/.storybook/scss/doc-narrow-sidebar.scss
@@ -75,7 +75,7 @@
       color: $purple-70;
 
 
-      .sidebar-item {
+      .lab-narrow-sidebar__item-icon {
         background-color: $purple-70;
       }
     }
@@ -138,7 +138,7 @@
     }
   }
 
-  .lab-narrow-sidebar__item{
+  .lab-narrow-sidebar__item {
     &:focus{
       &:before{
         border-color: $mineral-30;
@@ -159,7 +159,7 @@
       color: $mineral-70;
 
 
-      .sidebar-item {
+      .lab-narrow-sidebar__item-icon {
         background-color: $mineral-70;
       }
     }

--- a/.storybook/scss/doc-narrow-sidebar.scss
+++ b/.storybook/scss/doc-narrow-sidebar.scss
@@ -85,7 +85,7 @@
     &__button{
       color: $purple-60;
 
-      .sidebar-item {
+      .lab-narrow-sidebar__footer-icon {
         background-color: $purple-60;
       }
     }
@@ -107,7 +107,7 @@
       background-color: $purple-70;
       color: $purple-20;
 
-      .sidebar-item {
+      .lab-narrow-sidebar__footer-icon {
         background-color: $purple-70;
       }
     }
@@ -169,7 +169,7 @@
     &__button{
       color: $mineral-60;
 
-      .sidebar-item {
+      .lab-narrow-sidebar__footer-icon {
         background-color: $mineral-60;
       }
     }
@@ -191,7 +191,7 @@
       background-color: $mineral-70;
       color: $mineral-20;
 
-      .sidebar-item {
+      .lab-narrow-sidebar__footer-icon {
         background-color: $mineral-70;
       }
     }

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -297,7 +297,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
       font-size: $font-size-1;
     }
 
-    .sidebar-item {
+    .lab-narrow-sidebar__footer-icon {
       background-color: $footer-button-color;
       margin-right: $spacing-02;
 
@@ -325,7 +325,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
     color: $item-active-color;
     font-weight: $weight-semibold;
 
-    .sidebar-item {
+    .lab-narrow-sidebar__footer-icon {
       background-color: $item-active-color;
     }
   }
@@ -412,7 +412,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
   .lab-narrow-sidebar__footer__button {
     color: $white;
 
-    .sidebar-item {
+    .lab-narrow-sidebar__footer-icon {
       background-color: $white;
     }
 
@@ -433,7 +433,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
     background-color: $white;
     color: $vivid-bg;
 
-    .sidebar-item {
+    .lab-narrow-sidebar__footer-icon {
       background-color: $vivid-bg;
     }
   }

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -20,10 +20,10 @@ $footer-button-color: map-get($narrow-sidebar-theme, "60");
 }
 
 // Vivid Colors
-$narrow-bg: map-get($narrow-sidebar-theme, "60");
+$vivid-bg: map-get($narrow-sidebar-theme, "60");
 
 @if $narrow-sidebar-theme == $mineral-palette {
-  $narrow-bg: map-get($narrow-sidebar-theme, "90");
+  $vivid-bg: map-get($narrow-sidebar-theme, "90");
 }
 
 .lab-narrow-sidebar {
@@ -371,10 +371,10 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
 // Vivid Skin
 .lab-narrow-sidebar--vivid {
   border: transparent;
-  background: $narrow-bg;
+  background: $vivid-bg;
 
   .lab-narrow-sidebar__header {
-    background-color: $narrow-bg;
+    background-color: $vivid-bg;
   }
 
   // Unselected item
@@ -393,7 +393,7 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
     }
 
     &:active {
-      background-color: $narrow-bg;
+      background-color: $vivid-bg;
     }
 
     .sidebar-item {
@@ -404,7 +404,7 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
   // Selected item
   .lab-narrow-sidebar__item--active {
     background-color: $white;
-    color: $narrow-bg;
+    color: $vivid-bg;
 
     &:hover {
       color: $white;
@@ -415,7 +415,7 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
 
     &:focus {
       &:before {
-        border-color: $narrow-bg;
+        border-color: $vivid-bg;
       }
     }
 
@@ -426,11 +426,11 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
     }
 
     &:active {
-      background-color: $narrow-bg;
+      background-color: $vivid-bg;
     }
 
     .sidebar-item {
-      background-color: $narrow-bg;
+      background-color: $vivid-bg;
     }
   }
 
@@ -450,16 +450,16 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
     }
 
     &:active {
-      background-color: $narrow-bg;
+      background-color: $vivid-bg;
     }
   }
 
   .lab-narrow-sidebar__footer__button--active {
     background-color: $white;
-    color: $narrow-bg;
+    color: $vivid-bg;
 
     .sidebar-item {
-      background-color: $narrow-bg;
+      background-color: $vivid-bg;
     }
   }
 
@@ -474,9 +474,7 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
     }
   }
 
-  .lab-narrow-sidebar__collapse,
-  .lab-narrow-sidebar__mobile-button{
-
+  .lab-narrow-sidebar__collapse {
     &:focus{
       border-color: $white-50;
       outline: none;
@@ -486,7 +484,7 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
       background-color: $white-75;
 
       .lab-narrow-sidebar__collapse-icon {
-        background-color: $narrow-bg;
+        background-color: $vivid-bg;
       }
     }
   }
@@ -494,9 +492,6 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
   .lab-narrow-sidebar__collapse-icon {
     background-color: $white;
 
-    .lab-narrow-sidebar__collapse-icon{
-      background-color: $white;
-    }
   }
 
   .lab-narrow-sidebar__mobile-topbar {
@@ -506,7 +501,7 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
   .lab-narrow-sidebar__mobile-button {
     &:active {
       .lab-icon {
-        background-color: $narrow-bg;
+        background-color: $vivid-bg;
       }
     }
   }

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -212,7 +212,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
       border-radius: 0;
   }
 
-  .sidebar-item {
+  .lab-narrow-sidebar__item-icon {
     margin-right: $spacing-02;
 
     @include from($tablet){
@@ -254,7 +254,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
     font-weight: $weight-semibold;
     color: $item-active-color;
 
-    .sidebar-item {
+    .lab-narrow-sidebar__item-icon {
       background-color: $item-active-color;
     }
   }
@@ -371,7 +371,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
       background-color: $vivid-bg;
     }
 
-    .sidebar-item {
+    .lab-narrow-sidebar__item-icon {
       background-color: $white;
     }
   }
@@ -404,7 +404,7 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
       background-color: $vivid-bg;
     }
 
-    .sidebar-item {
+    .lab-narrow-sidebar__item-icon {
       background-color: $vivid-bg;
     }
   }

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -194,6 +194,7 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
   align-self: flex-start;
   width: 100%;
   flex-direction: column;
+  flex-grow: 1;
   padding: $spacing-01 0;
   margin-top: 76px;
 

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -159,6 +159,10 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
     background-color: $item-focus-color;
   }
 
+  .sidebar-item {
+    background-color: $item-active-color;
+  }
+
   @include from($tablet){
     display: none;
   }
@@ -181,6 +185,7 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
 
   &:active {
     background-color: $item-focus-color;
+
     .lab-icon {
       background-color: $item-active-color;
     }

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -159,13 +159,13 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
     background-color: $item-focus-color;
   }
 
-  .sidebar-item {
-    background-color: $item-active-color;
-  }
-
   @include from($tablet){
     display: none;
   }
+}
+
+.lab-narrow-sidebar__collapse-icon {
+  background-color: $item-active-color;
 }
 
 .lab-narrow-sidebar__mobile-button {
@@ -485,12 +485,16 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
     &:active {
       background-color: $white-75;
 
-      .sidebar-item {
+      .lab-narrow-sidebar__collapse-icon {
         background-color: $narrow-bg;
       }
     }
+  }
 
-    .sidebar-item{
+  .lab-narrow-sidebar__collapse-icon {
+    background-color: $white;
+
+    .lab-narrow-sidebar__collapse-icon{
       background-color: $white;
     }
   }

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -386,6 +386,10 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
       background-color: $white-20;
     }
 
+    &:active {
+      background-color: $narrow-bg;
+    }
+
     .sidebar-item {
       background-color: $white;
     }
@@ -440,16 +444,16 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
     }
 
     &:active {
-      background-color: $white-75;
+      background-color: $narrow-bg;
     }
+  }
 
-    .lab-narrow-sidebar__footer__button--active {
-      background-color: $white;
-      color: $narrow-bg;
+  .lab-narrow-sidebar__footer__button--active {
+    background-color: $white;
+    color: $narrow-bg;
 
-      .sidebar-item {
-        background-color: $narrow-bg;
-      }
+    .sidebar-item {
+      background-color: $narrow-bg;
     }
   }
 
@@ -487,8 +491,10 @@ $narrow-bg: map-get($narrow-sidebar-theme, "60");
 
   .lab-narrow-sidebar__mobile-topbar {
     background-color: $white;
+  }
 
-    &-button:active {
+  .lab-narrow-sidebar__mobile-button {
+    &:active {
       .lab-icon {
         background-color: $narrow-bg;
       }

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -168,31 +168,6 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
   background-color: $item-active-color;
 }
 
-.lab-narrow-sidebar__mobile-button {
-  display: flex;
-  align-items: center;
-  width: 40px;
-  height: 40px;
-  margin: 18px 0 18px 12px;
-  background-color: transparent;
-  border: $border-default transparent;
-  border-radius: $radius-02;
-
-  &:focus {
-    border-color: $item-focus-color;
-    outline: none;
-  }
-
-  &:active {
-    background-color: $item-focus-color;
-
-    .lab-icon {
-      background-color: $item-active-color;
-    }
-  }
-
-}
-
 //Body
 .lab-narrow-sidebar__body {
   display: flex;
@@ -491,18 +466,5 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
 
   .lab-narrow-sidebar__collapse-icon {
     background-color: $white;
-
-  }
-
-  .lab-narrow-sidebar__mobile-topbar {
-    background-color: $white;
-  }
-
-  .lab-narrow-sidebar__mobile-button {
-    &:active {
-      .lab-icon {
-        background-color: $vivid-bg;
-      }
-    }
   }
 }

--- a/labsystem/src/Icon.js
+++ b/labsystem/src/Icon.js
@@ -74,7 +74,8 @@ export default class Icon extends React.Component {
     return (
       <span
         className={
-          `lab-icon lab-icon--${type} lab-icon--${color}` +
+          `lab-icon lab-icon--${type}` +
+          `${color ? ` lab-icon--${color}` : ""}` +
           `${size ? ` lab-icon--${size}` : ""}` +
           `${className ? ` ${className}` : ""}`
         }

--- a/labsystem/src/Input/__snapshots__/AbstractTextInput.test.js.snap
+++ b/labsystem/src/Input/__snapshots__/AbstractTextInput.test.js.snap
@@ -34,7 +34,7 @@ exports[`AbstractTextInput renders icon when it is passed by props 1`] = `
     type="button"
   >
     <span
-      className="lab-icon lab-icon--star lab-icon--undefined"
+      className="lab-icon lab-icon--star"
     />
   </button>
   
@@ -116,7 +116,7 @@ exports[`AbstractTextInput renders required icon when it is passed by props 1`] 
     type="button"
   >
     <span
-      className="lab-icon lab-icon--star lab-icon--undefined"
+      className="lab-icon lab-icon--star"
     />
   </button>
   

--- a/labsystem/src/Input/__snapshots__/PasswordInput.test.js.snap
+++ b/labsystem/src/Input/__snapshots__/PasswordInput.test.js.snap
@@ -35,7 +35,7 @@ exports[`PasswordInput renders icon when it is passed by props 1`] = `
     type="button"
   >
     <span
-      className="lab-icon lab-icon--eye-closed lab-icon--undefined"
+      className="lab-icon lab-icon--eye-closed"
     />
   </button>
   
@@ -85,7 +85,7 @@ exports[`PasswordInput renders prefix when it is passed by props 1`] = `
     type="button"
   >
     <span
-      className="lab-icon lab-icon--eye-closed lab-icon--undefined"
+      className="lab-icon lab-icon--eye-closed"
     />
   </button>
   
@@ -127,7 +127,7 @@ exports[`PasswordInput renders required icon when it is passed by props 1`] = `
     type="button"
   >
     <span
-      className="lab-icon lab-icon--eye-closed lab-icon--undefined"
+      className="lab-icon lab-icon--eye-closed"
     />
   </button>
   
@@ -173,7 +173,7 @@ exports[`PasswordInput renders suffix when it is passed by props 1`] = `
     type="button"
   >
     <span
-      className="lab-icon lab-icon--eye-closed lab-icon--undefined"
+      className="lab-icon lab-icon--eye-closed"
     />
   </button>
   
@@ -215,7 +215,7 @@ exports[`PasswordInput renders with base props 1`] = `
     type="button"
   >
     <span
-      className="lab-icon lab-icon--eye-closed lab-icon--undefined"
+      className="lab-icon lab-icon--eye-closed"
     />
   </button>
   

--- a/labsystem/src/Sidebar/CollapseButton.js
+++ b/labsystem/src/Sidebar/CollapseButton.js
@@ -6,7 +6,10 @@ export default class Collapse extends React.Component {
     return (
       <React.Fragment>
         <button type="button" href="#" className="lab-narrow-sidebar__collapse">
-          <Icon type="menu-collapse" className="sidebar-item" />
+          <Icon
+            type="menu-collapse"
+            className="lab-narrow-sidebar__collapse-icon"
+          />
         </button>
       </React.Fragment>
     );

--- a/labsystem/src/Sidebar/FooterButton.js
+++ b/labsystem/src/Sidebar/FooterButton.js
@@ -22,7 +22,11 @@ export default class FooterButton extends React.Component {
 
   buttonIcon = () => {
     const { icon } = this.props;
-    return icon ? <Icon type={icon} className="sidebar-item" /> : "";
+    return icon ? (
+      <Icon type={icon} className="lab-narrow-sidebar__footer-icon" />
+    ) : (
+      ""
+    );
   };
 
   render() {

--- a/labsystem/src/Sidebar/Item.js
+++ b/labsystem/src/Sidebar/Item.js
@@ -25,7 +25,11 @@ export default class Item extends React.Component {
   itemIcon = () => {
     const { icon } = this.props;
     return icon ? (
-      <Icon type={icon} color="mineral-60" className="sidebar-item" />
+      <Icon
+        type={icon}
+        color="mineral-60"
+        className="lab-narrow-sidebar__item-icon"
+      />
     ) : (
       ""
     );


### PR DESCRIPTION
Issue: https://labcodes.atlassian.net/browse/DSYS-73 

Fixes:
- ​​​​Fix Footer position - it doesn’t stay in the bottom of the sidebar if the number of body items is smal

- Fix the collapse icon color in the mobile version - it isn’t changing color

- When no color is passed to the Icon it renders a className called “lab-icon-undefined”. Fixed that on Icon.js file.

- Several internal components of narrow sidebar (item, collapse and footer button) were creating an icon with the className sidebar-item. Besides having a typo (I believe it was supposed to be sidebar-icon) it wasn’t very clear and not following BEM conventions. I renamed those icons.

