### PR TITLE
DSYS-23: Dialogs

### DIFF
--- a/labsystem/package-lock.json
+++ b/labsystem/package-lock.json
@@ -3314,6 +3314,22 @@
         "path-exists": "^4.0.0"
       }
     },
+    "focus-trap": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.0.tgz",
+      "integrity": "sha512-CO9ovKkTdoo4eKQJ2/nLIsDyCwEDKfbeuW27PqFJZQoPzVwrbDj6RhPvVxPbj2kzOrWN7sVEMeIVzeqSXFd15g==",
+      "requires": {
+        "tabbable": "^5.1.3"
+      }
+    },
+    "focus-trap-react": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-8.3.0.tgz",
+      "integrity": "sha512-FtSEIcI1jec7L4Mlx8ZGaAdctcmZfdyZLX3FgbqF7n3/C1dFmRbbF7c+vmTHHsS2qoJQUQoht2p0XDTPeiZ6eA==",
+      "requires": {
+        "focus-trap": "^6.2.0"
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -7217,6 +7233,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tabbable": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.1.3.tgz",
+      "integrity": "sha512-jqR3rOgeyNlYWDWoyjNTWuHk3+FObu3Fw4e0zjeOLBicI74TT/wGrvSbJUaFVs7FMfiY0Ee8CKM7QaJwVMT4YA=="
     },
     "terminal-link": {
       "version": "2.1.1",

--- a/labsystem/package.json
+++ b/labsystem/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "bulma": "^0.8.1",
+    "focus-trap-react": "^8.3.0",
     "lodash": "^4.17.19",
     "prop-types": "^15.7.2",
     "react": "^16.13.1"

--- a/labsystem/scss/components/_all.scss
+++ b/labsystem/scss/components/_all.scss
@@ -9,3 +9,4 @@
 @import "lab-tooltip";
 @import "lab-alerts";
 @import "lab-tag";
+@import "lab-dialog";

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -20,7 +20,6 @@
   z-index: 2;
 
   width: 24rem;
-  height: 10rem;
   padding: 1rem;
   border-radius: 5px;
 }
@@ -76,4 +75,8 @@
 }
 
 .lab-dialog--large {
+}
+
+.lab-dialog__mobile-close-button {
+  width: 100%;
 }

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -2,10 +2,27 @@
 
 // Standard Dialog component
 .lab-dialog {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 2;
+}
+
+.lab-dialog__container {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: white;
+  padding: 1rem 1.5rem;
+  width: 24rem;
+  height: 10rem;
+  border-radius: 0.5rem;
 }
 
 .lab-dialog--standard {
-  border: 1px solid;
 }
 
 .lab-dialog__header {

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -5,33 +5,58 @@
   border: 1px solid;
 
   &--standard {
+
+    &__header-wrapper {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    &__title {
+      color: $teal-40;
+      font-weight: $weight-bold;
+    }
+
+    &__content {
+      min-width: 100%;
+      width: 0;
+      overflow-x: auto;
+    }
+
+    &__footer-wrapper {
+      display: flex;
+      justify-content: flex-end;
+      background: $mineral-10;
+    }
+
+    &__optional-button {
+    }
+
+    &__button {
+    }
   }
-}
 
-.lab-dialog__header-wrapper {
-  display: flex;
-  justify-content: space-between;
-}
+  &--message {
+    &__header-wrapper {
+      display: flex;
+      justify-content: flex-end;
+    }
 
-.lab-dialog__title {
-  color: $teal-40;
-  font-weight: $weight-bold;
-}
+    &__icon {
+    }
 
-.lab-dialog__content {
-  min-width: 100%;
-  width: 0;
-  overflow-x: auto;
-}
+    &__title {
+    }
 
-.lab-dialog__footer-wrapper {
-  display: flex;
-  justify-content: flex-end;
-  background: $mineral-10;
-}
+    &__content {
+    }
 
-.lab-dialog__optional-button {
-}
+    &__button {
+    }
+  }
 
-.lab-dialog__button {
+  &__close-button--with-background {
+  }
+
+  &__close-button--without-background {
+  }
 }

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -2,17 +2,32 @@
 
 // Standard Dialog component
 .lab-dialog {
-  font-size: 20px
+
+  &--standard {
+  }
+}
+
+.lab-dialog__header-wrapper {
+  display: flex;
+  justify-content: space-between;
 }
 
 .lab-dialog__title {
-  display: flex;
   color: $teal-40;
   font-weight: $weight-bold;
-  padding: $spacing-03 $spacing-04;
 }
 
 .lab-dialog__content {
+}
+
+.lab-dialog__footer-wrapper {
   display: flex;
-  padding: $spacing-03 $spacing-04;
+  justify-content: flex-end;
+  background: $mineral-10;
+}
+
+.lab-dialog__optional-button {
+}
+
+.lab-dialog__button {
 }

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -2,7 +2,7 @@
 
 // Standard Dialog component
 .lab-dialog-overlay {
-  z-index: 1;
+  z-index: 2;
   position: fixed;
   top: 0;
   left: 0;
@@ -80,6 +80,6 @@
 .lab-dialog__close-button {
 }
 
-.lab-dialog__close-button--mobile {
+.lab-dialog__mobile-close-button {
   width: 100%;
 }

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -1,0 +1,18 @@
+@use 'sass:map';
+
+// Standard Dialog component
+.lab-dialog {
+  font-size: 20px
+}
+
+.lab-dialog__title {
+  display: flex;
+  color: $teal-40;
+  font-weight: $weight-bold;
+  padding: $spacing-03 $spacing-04;
+}
+
+.lab-dialog__content {
+  display: flex;
+  padding: $spacing-03 $spacing-04;
+}

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -18,6 +18,9 @@
 }
 
 .lab-dialog__content {
+  min-width: 100%;
+  width: 0;
+  overflow-x: auto;
 }
 
 .lab-dialog__footer-wrapper {

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -2,69 +2,71 @@
 
 // Standard Dialog component
 .lab-dialog {
+}
+
+.lab-dialog--standard {
   border: 1px solid;
+}
 
-  &--standard {
+.lab-dialog__standard-header {
+  display: flex;
+  justify-content: space-between;
+}
 
-    &__header-wrapper {
-      display: flex;
-      justify-content: space-between;
-    }
+.lab-dialog__standard-title {
+  color: $teal-40;
+  font-weight: $weight-bold;
+}
 
-    &__title {
-      color: $teal-40;
-      font-weight: $weight-bold;
-    }
+.lab-dialog__standard-content {
+  min-width: 100%;
+  width: 0;
+  overflow-x: auto;
+}
 
-    &__content {
-      min-width: 100%;
-      width: 0;
-      overflow-x: auto;
-    }
+.lab-dialog__standard-footer {
+  display: flex;
+  justify-content: flex-end;
+  background: $mineral-10;
+}
 
-    &__footer-wrapper {
-      display: flex;
-      justify-content: flex-end;
-      background: $mineral-10;
-    }
+.lab-dialog__optional-button {
+}
 
-    &__optional-button {
-    }
+.lab-dialog__button {
+}
 
-    &__button {
-    }
-  }
+.lab-dialog--message {
+  border: 1px solid;
+}
 
-  &--message {
-    &__header-wrapper {
-      display: flex;
-      justify-content: flex-end;
-    }
+.lab-dialog__icon {
+  display: flex;
+  justify-content: center;
+}
 
-    &__icon {
-      display: flex;
-      justify-content: center;
-    }
+.lab-dialog__message-header {
+  display: flex;
+  justify-content: flex-end;
+}
 
-    &__title {
-      display: flex;
-      justify-content: center;
-      color: $teal-40;
-      font-weight: $weight-bold;
-    }
+.lab-dialog__message-title {
+  display: flex;
+  justify-content: center;
+  color: $teal-40;
+  font-weight: $weight-bold;
+}
 
-    &__content {
-      display:flex;
-      justify-content: center;
-    }
+.lab-dialog__message-content {
+  display:flex;
+  justify-content: center;
+}
 
-    &__button {
-    }
-  }
+.lab-dialog-close-button--with-background {
+}
 
-  &__close-button--with-background {
-  }
+.lab-dialog.close-button {
+}
 
-  &__close-button--without-background {
-  }
+.lab-dialog--large {
 }

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -8,32 +8,26 @@
   border: 1px solid;
 }
 
-.lab-dialog__standard-header {
+.lab-dialog__header {
   display: flex;
   justify-content: space-between;
 }
 
-.lab-dialog__standard-title {
+.lab-dialog__title {
   color: $teal-40;
   font-weight: $weight-bold;
 }
 
-.lab-dialog__standard-content {
+.lab-dialog__content {
   min-width: 100%;
   width: 0;
   overflow-x: auto;
 }
 
-.lab-dialog__standard-footer {
+.lab-dialog__footer {
   display: flex;
   justify-content: flex-end;
   background: $mineral-10;
-}
-
-.lab-dialog__optional-button {
-}
-
-.lab-dialog__button {
 }
 
 .lab-dialog--message {
@@ -45,27 +39,21 @@
   justify-content: center;
 }
 
-.lab-dialog__message-header {
+.lab-dialog__header--message{
   display: flex;
   justify-content: flex-end;
 }
 
-.lab-dialog__message-title {
+.lab-dialog__title--message {
   display: flex;
   justify-content: center;
   color: $teal-40;
   font-weight: $weight-bold;
 }
 
-.lab-dialog__message-content {
+.lab-dialog__content--message {
   display:flex;
   justify-content: center;
-}
-
-.lab-dialog-close-button--with-background {
-}
-
-.lab-dialog.close-button {
 }
 
 .lab-dialog--large {

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -77,6 +77,9 @@
 .lab-dialog--large {
 }
 
-.lab-dialog__mobile-close-button {
+.lab-dialog__close-button {
+}
+
+.lab-dialog__close-button--mobile {
   width: 100%;
 }

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -42,12 +42,20 @@
     }
 
     &__icon {
+      display: flex;
+      justify-content: center;
     }
 
     &__title {
+      display: flex;
+      justify-content: center;
+      color: $teal-40;
+      font-weight: $weight-bold;
     }
 
     &__content {
+      display:flex;
+      justify-content: center;
     }
 
     &__button {

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -1,9 +1,8 @@
 @use 'sass:map';
 
 // Standard Dialog component
-
-.lab-dialog__container {
-  z-index: 2;
+.lab-dialog-overlay {
+  z-index: 1;
   position: fixed;
   top: 0;
   left: 0;
@@ -17,6 +16,9 @@
 
 .lab-dialog {
   background-color: #fefefe;
+  position: fixed;
+  z-index: 2;
+
   width: 24rem;
   height: 10rem;
   padding: 1rem;
@@ -49,7 +51,6 @@
 }
 
 .lab-dialog--message {
-  border: 1px solid;
 }
 
 .lab-dialog__icon {

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -2,6 +2,7 @@
 
 // Standard Dialog component
 .lab-dialog {
+  border: 1px solid;
 
   &--standard {
   }

--- a/labsystem/scss/components/_lab-dialog.scss
+++ b/labsystem/scss/components/_lab-dialog.scss
@@ -1,25 +1,26 @@
 @use 'sass:map';
 
 // Standard Dialog component
-.lab-dialog {
-  position: fixed;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
-  z-index: 2;
-}
 
 .lab-dialog__container {
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  background-color: white;
-  padding: 1rem 1.5rem;
+  z-index: 2;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.lab-dialog {
+  background-color: #fefefe;
   width: 24rem;
   height: 10rem;
-  border-radius: 0.5rem;
+  padding: 1rem;
+  border-radius: 5px;
 }
 
 .lab-dialog--standard {

--- a/labsystem/src/Dialog.js
+++ b/labsystem/src/Dialog.js
@@ -1,7 +1,0 @@
-import React from "react";
-
-export default class Dialog extends React.Component {
-  render() {
-    return <h1>Dialog Component</h1>;
-  }
-}

--- a/labsystem/src/Dialog.js
+++ b/labsystem/src/Dialog.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class Dialog extends React.Component {
+  render() {
+    return <h1>Dialog Component</h1>;
+  }
+}

--- a/labsystem/src/Dialog/DialogWrapper.js
+++ b/labsystem/src/Dialog/DialogWrapper.js
@@ -1,0 +1,70 @@
+import React from "react";
+import PropTypes from "prop-types";
+import FocusTrap from "focus-trap-react";
+
+export default class DialogWrapper extends React.Component {
+  static propTypes = {
+    handleClose: PropTypes.func.isRequired,
+    isOpen: PropTypes.bool.isRequired,
+    isModal: PropTypes.bool.isRequired,
+    children: PropTypes.node.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    const { isOpen, isModal } = props;
+    const deviceIsMobile = window.outerWidth <= 768;
+    this.state = {
+      shouldToggleOverflow: isOpen && (isModal || deviceIsMobile),
+    };
+  }
+
+  componentDidMount() {
+    window.addEventListener("resize", this.handleResize);
+  }
+
+  componentDidUpdate() {
+    this.handleOverflow();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.handleResize, false);
+    document.body.style.overflow = "unset";
+  }
+
+  handleOverflow = () => {
+    const { shouldToggleOverflow } = this.state;
+    document.body.style.overflow = shouldToggleOverflow ? "hidden" : "unset";
+  };
+
+  handleResize = () => {
+    const { isOpen, isModal } = this.props;
+    const deviceIsMobile = window.outerWidth <= 768;
+    this.setState({
+      shouldToggleOverflow: isOpen && (isModal || deviceIsMobile),
+    });
+  };
+
+  render() {
+    const { handleClose, children } = this.props;
+    const { shouldToggleOverflow } = this.state;
+    return (
+      <React.Fragment>
+        {shouldToggleOverflow ? (
+          <React.Fragment>
+            <div
+              className="lab-dialog-overlay"
+              onClick={handleClose}
+              role="presentation"
+            />
+            <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+              {children}
+            </FocusTrap>
+          </React.Fragment>
+        ) : (
+          <React.Fragment>{children}</React.Fragment>
+        )}
+      </React.Fragment>
+    );
+  }
+}

--- a/labsystem/src/Dialog/DialogWrapper.js
+++ b/labsystem/src/Dialog/DialogWrapper.js
@@ -48,23 +48,19 @@ export default class DialogWrapper extends React.Component {
   render() {
     const { handleClose, children } = this.props;
     const { shouldToggleOverflow } = this.state;
-    return (
+    return shouldToggleOverflow ? (
       <React.Fragment>
-        {shouldToggleOverflow ? (
-          <React.Fragment>
-            <div
-              className="lab-dialog-overlay"
-              onClick={handleClose}
-              role="presentation"
-            />
-            <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
-              {children}
-            </FocusTrap>
-          </React.Fragment>
-        ) : (
-          <React.Fragment>{children}</React.Fragment>
-        )}
+        <div
+          className="lab-dialog-overlay"
+          onClick={handleClose}
+          role="presentation"
+        />
+        <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+          {children}
+        </FocusTrap>
       </React.Fragment>
+    ) : (
+      <React.Fragment>{children}</React.Fragment>
     );
   }
 }

--- a/labsystem/src/Dialog/DialogWrapper.js
+++ b/labsystem/src/Dialog/DialogWrapper.js
@@ -21,6 +21,7 @@ export default class DialogWrapper extends React.Component {
 
   componentDidMount() {
     window.addEventListener("resize", this.handleResize);
+    this.handleOverflow();
   }
 
   componentDidUpdate() {

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -1,9 +1,11 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Button } from "../Buttons";
+import Icon from "../Icon";
 
 export default class MessageDialog extends React.Component {
   static propTypes = {
+    icon: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
     buttonProps: PropTypes.shape({
@@ -14,6 +16,7 @@ export default class MessageDialog extends React.Component {
 
   render() {
     const {
+      icon,
       title,
       content,
       buttonProps,
@@ -24,7 +27,12 @@ export default class MessageDialog extends React.Component {
         <div className="lab-dialog--message__header-wrapper">
           <div className="lab-dialog__close-button--without-background">close button</div>
         </div>
-        <div className="lab-dialog--message__icon">icon</div>
+        <div className="lab-dialog--message__icon">
+          <Icon
+            type={icon}
+            color="black-75"
+          />
+        </div>
         <div className="lab-dialog--message__title">{title}</div>
         <div className="lab-dialog--message__content">{content}</div>
         <div className="lab-dialog--message__button">

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -120,9 +120,13 @@ export default class MessageDialog extends React.Component {
             <Icon type={icon} color="black-75" />
           </div>
 
-          <div className="lab-dialog__title--message">{title}</div>
+          <div className="lab-dialog__title lab-dialog__title--message">
+            {title}
+          </div>
 
-          <div className="lab-dialog__content--message">{content}</div>
+          <div className="lab-dialog__content lab-dialog__content--message">
+            {content}
+          </div>
 
           <div className="lab-dialog__footer">
             {outlineButtonProps ? (

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import FocusTrap from "focus-trap-react";
-import { Button } from "../Buttons";
+import { Button, OutlineButton } from "../Buttons";
 import Icon from "../Icon";
 
 export default class MessageDialog extends React.Component {
@@ -13,12 +13,17 @@ export default class MessageDialog extends React.Component {
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }).isRequired,
+    outlineButtonProps: PropTypes.shape({
+      text: PropTypes.string.isRequired,
+      onClick: PropTypes.func.isRequired,
+    }),
     isLarge: PropTypes.bool,
     handleClose: PropTypes.func,
     isOpen: PropTypes.bool,
   };
 
   static defaultProps = {
+    outlineButtonProps: undefined,
     isLarge: false,
     handleClose: () => {},
     isOpen: false,
@@ -51,6 +56,7 @@ export default class MessageDialog extends React.Component {
       title,
       content,
       buttonProps,
+      outlineButtonProps,
       isLarge,
       isOpen,
       handleClose,
@@ -83,12 +89,21 @@ export default class MessageDialog extends React.Component {
             </div>
             <div className="lab-dialog__title--message">{title}</div>
             <div className="lab-dialog__content--message">{content}</div>
-            <Button
-              size="normal"
-              fullWidth
-              text={buttonProps.text}
-              onClick={buttonProps.onClick}
-            />
+            <div className="lab-dialog__footer">
+              {outlineButtonProps ? (
+                <OutlineButton
+                  size="normal"
+                  text={outlineButtonProps.text}
+                  onClick={outlineButtonProps.onClick}
+                />
+              ) : undefined}
+              <Button
+                size="normal"
+                {...(outlineButtonProps ? undefined : { fullWidth: true })}
+                text={buttonProps.text}
+                onClick={buttonProps.onClick}
+              />
+            </div>
           </div>
         </FocusTrap>
       </>

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -23,6 +23,11 @@ export default class MessageDialog extends React.Component {
     isOpen: false,
   };
 
+  componentDidUpdate() {
+    const { isOpen } = this.props;
+    document.body.style.overflow = isOpen ? "hidden" : "unset";
+  }
+
   render() {
     const {
       icon,
@@ -42,22 +47,24 @@ export default class MessageDialog extends React.Component {
           `${isLarge ? ` lab-dialog--large` : ""}`
         }
       >
-        <div className="lab-dialog__header lab-dialog__header--message">
-          <button type="button" onClick={handleClose}>
-            x
-          </button>
+        <div className="lab-dialog lab-dialog__container">
+          <div className="lab-dialog__header lab-dialog__header--message">
+            <button type="button" onClick={handleClose}>
+              x
+            </button>
+          </div>
+          <div className="lab-dialog__icon">
+            <Icon type={icon} color="black-75" />
+          </div>
+          <div className="lab-dialog__title--message">{title}</div>
+          <div className="lab-dialog__content--message">{content}</div>
+          <Button
+            size="normal"
+            fullWidth
+            text={buttonProps.text}
+            onClick={buttonProps.onClick}
+          />
         </div>
-        <div className="lab-dialog__icon">
-          <Icon type={icon} color="black-75" />
-        </div>
-        <div className="lab-dialog__title--message">{title}</div>
-        <div className="lab-dialog__content--message">{content}</div>
-        <Button
-          size="normal"
-          fullWidth
-          text={buttonProps.text}
-          onClick={buttonProps.onClick}
-        />
       </div>
     );
   }

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -109,7 +109,7 @@ export default class MessageDialog extends React.Component {
           >
             <button
               type="button"
-              className="lab-dialog__mobile-close-button"
+              className="lab-dialog__close-button--mobile"
               onClick={handleClose}
               onTouchStart={this.handleTouchStart}
               onTouchEnd={this.handleTouchEnd}
@@ -117,7 +117,11 @@ export default class MessageDialog extends React.Component {
               <Icon type="collapse-open" size="petit" />
             </button>
             <div className="lab-dialog__header lab-dialog__header--message">
-              <button type="button" onClick={handleClose}>
+              <button
+                className="lab-dialog__close-button"
+                type="button"
+                onClick={handleClose}
+              >
                 <Icon type="remove" />
               </button>
             </div>

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import FocusTrap from "focus-trap-react";
+import DialogWrapper from "./DialogWrapper";
 import { Button, OutlineButton } from "../Buttons";
 import Icon from "../Icon";
 
@@ -43,14 +43,8 @@ export default class MessageDialog extends React.Component {
     document.addEventListener("keydown", this.handleKeyDown, false);
   }
 
-  componentDidUpdate() {
-    const { isOpen, isModal } = this.props;
-    document.body.style.overflow = isOpen && isModal ? "hidden" : "unset";
-  }
-
   componentWillUnmount() {
     document.removeEventListener("keydown", this.handleKeyDown, false);
-    document.body.style.overflow = "unset";
   }
 
   handleKeyDown = (event) => {
@@ -90,68 +84,63 @@ export default class MessageDialog extends React.Component {
 
     if (!isOpen) return null;
     return (
-      <React.Fragment>
-        {isModal ? (
-          <div
-            className="lab-dialog-overlay"
+      <DialogWrapper
+        handleClose={handleClose}
+        isOpen={isOpen}
+        isModal={isModal}
+      >
+        <div
+          className={
+            `lab-dialog lab-dialog--message` +
+            `${isLarge ? ` lab-dialog--large` : ""}`
+          }
+          role="dialog"
+          aria-modal="true"
+        >
+          <button
+            type="button"
+            className="lab-dialog__mobile-close-button"
             onClick={handleClose}
-            role="presentation"
-          />
-        ) : null}
-        <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
-          <div
-            className={
-              `lab-dialog lab-dialog--message` +
-              `${isLarge ? ` lab-dialog--large` : ""}`
-            }
-            role="dialog"
-            aria-modal="true"
+            onTouchStart={this.handleTouchStart}
+            onTouchEnd={this.handleTouchEnd}
           >
+            <Icon type="collapse-open" size="petit" />
+          </button>
+          <div className="lab-dialog__header lab-dialog__header--message">
             <button
+              className="lab-dialog__close-button"
               type="button"
-              className="lab-dialog__mobile-close-button"
               onClick={handleClose}
-              onTouchStart={this.handleTouchStart}
-              onTouchEnd={this.handleTouchEnd}
             >
-              <Icon type="collapse-open" size="petit" />
+              <Icon type="remove" />
             </button>
-            <div className="lab-dialog__header lab-dialog__header--message">
-              <button
-                className="lab-dialog__close-button"
-                type="button"
-                onClick={handleClose}
-              >
-                <Icon type="remove" />
-              </button>
-            </div>
-
-            <div className="lab-dialog__icon">
-              <Icon type={icon} color="black-75" />
-            </div>
-
-            <div className="lab-dialog__title--message">{title}</div>
-
-            <div className="lab-dialog__content--message">{content}</div>
-
-            <div className="lab-dialog__footer">
-              {outlineButtonProps ? (
-                <OutlineButton
-                  size="normal"
-                  text={outlineButtonProps.text}
-                  onClick={outlineButtonProps.onClick}
-                />
-              ) : undefined}
-              <Button
-                size="normal"
-                {...(outlineButtonProps ? undefined : { fullWidth: true })}
-                text={buttonProps.text}
-                onClick={buttonProps.onClick}
-              />
-            </div>
           </div>
-        </FocusTrap>
-      </React.Fragment>
+
+          <div className="lab-dialog__icon">
+            <Icon type={icon} color="black-75" />
+          </div>
+
+          <div className="lab-dialog__title--message">{title}</div>
+
+          <div className="lab-dialog__content--message">{content}</div>
+
+          <div className="lab-dialog__footer">
+            {outlineButtonProps ? (
+              <OutlineButton
+                size="normal"
+                text={outlineButtonProps.text}
+                onClick={outlineButtonProps.onClick}
+              />
+            ) : undefined}
+            <Button
+              size="normal"
+              {...(outlineButtonProps ? undefined : { fullWidth: true })}
+              text={buttonProps.text}
+              onClick={buttonProps.onClick}
+            />
+          </div>
+        </div>
+      </DialogWrapper>
     );
   }
 }

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -19,17 +19,15 @@ export default class MessageDialog extends React.Component {
 
     return (
       <div className="lab-dialog lab-dialog--message">
-        <div className="lab-dialog--message__header-wrapper">
-          <div className="lab-dialog__close-button--without-background">
-            close button
-          </div>
+        <div className="lab-dialog__message-header">
+          <div className="lab-dialog__close-button">close button</div>
         </div>
-        <div className="lab-dialog--message__icon">
+        <div className="lab-dialog__icon">
           <Icon type={icon} color="black-75" />
         </div>
-        <div className="lab-dialog--message__title">{title}</div>
-        <div className="lab-dialog--message__content">{content}</div>
-        <div className="lab-dialog--message__button">
+        <div className="lab-dialog__message-title">{title}</div>
+        <div className="lab-dialog__message-content">{content}</div>
+        <div className="lab-dialog__button">
           <Button
             size="normal"
             fullWidth

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class MessageDialog extends React.Component {
+  render() {
+    return <p>MessageDialog Component</p>;
+  }
+}

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -118,7 +118,7 @@ export default class MessageDialog extends React.Component {
             </button>
             <div className="lab-dialog__header lab-dialog__header--message">
               <button type="button" onClick={handleClose}>
-                x
+                <Icon type="remove" />
               </button>
             </div>
 

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -23,9 +23,29 @@ export default class MessageDialog extends React.Component {
     isOpen: false,
   };
 
+  constructor(props) {
+    super(props);
+    this.escFunction = this.escFunction.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener("keydown", this.escFunction, false);
+  }
+
   componentDidUpdate() {
     const { isOpen } = this.props;
     document.body.style.overflow = isOpen ? "hidden" : "unset";
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.escFunction, false);
+  }
+
+  escFunction(event) {
+    const { handleClose } = this.props;
+    if (event.keyCode === 27) {
+      handleClose();
+    }
   }
 
   render() {
@@ -41,13 +61,13 @@ export default class MessageDialog extends React.Component {
 
     if (!isOpen) return null;
     return (
-      <div
-        className={
-          `lab-dialog lab-dialog--message` +
-          `${isLarge ? ` lab-dialog--large` : ""}`
-        }
-      >
-        <div className="lab-dialog lab-dialog__container">
+      <div className="lab-dialog__container" role="dialog" aria-modal="true">
+        <div
+          className={
+            `lab-dialog lab-dialog--message` +
+            `${isLarge ? ` lab-dialog--large` : ""}`
+          }
+        >
           <div className="lab-dialog__header lab-dialog__header--message">
             <button type="button" onClick={handleClose}>
               x

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -12,13 +12,19 @@ export default class MessageDialog extends React.Component {
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }).isRequired,
+    isLarge: PropTypes.bool,
   };
 
   render() {
-    const { icon, title, content, buttonProps } = this.props;
+    const { icon, title, content, buttonProps, isLarge } = this.props;
 
     return (
-      <div className="lab-dialog lab-dialog--message">
+      <div
+        className={
+          `lab-dialog lab-dialog--message` +
+          `${isLarge ? ` lab-dialog--large` : ""}`
+        }
+      >
         <div className="lab-dialog__message-header">
           <div className="lab-dialog__close-button">close button</div>
         </div>

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -15,6 +15,10 @@ export default class MessageDialog extends React.Component {
     isLarge: PropTypes.bool,
   };
 
+  static defaultProps = {
+    isLarge: false,
+  }
+
   render() {
     const { icon, title, content, buttonProps, isLarge } = this.props;
 
@@ -25,22 +29,20 @@ export default class MessageDialog extends React.Component {
           `${isLarge ? ` lab-dialog--large` : ""}`
         }
       >
-        <div className="lab-dialog__message-header">
-          <div className="lab-dialog__close-button">close button</div>
+        <div className="lab-dialog__header lab-dialog__header--message">
+          <div>close button</div>
         </div>
         <div className="lab-dialog__icon">
           <Icon type={icon} color="black-75" />
         </div>
-        <div className="lab-dialog__message-title">{title}</div>
-        <div className="lab-dialog__message-content">{content}</div>
-        <div className="lab-dialog__button">
-          <Button
-            size="normal"
-            fullWidth
-            text={buttonProps.text}
-            onClick={buttonProps.onClick}
-          />
-        </div>
+        <div className="lab-dialog__title--message">{title}</div>
+        <div className="lab-dialog__content--message">{content}</div>
+        <Button
+          size="normal"
+          fullWidth
+          text={buttonProps.text}
+          onClick={buttonProps.onClick}
+        />
       </div>
     );
   }

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -9,11 +9,11 @@ export default class MessageDialog extends React.Component {
     icon: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
-    buttonProps: PropTypes.shape({
+    buttonProps: PropTypes.exact({
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }).isRequired,
-    outlineButtonProps: PropTypes.shape({
+    outlineButtonProps: PropTypes.exact({
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }),
@@ -28,6 +28,14 @@ export default class MessageDialog extends React.Component {
     handleClose: () => {},
     isOpen: false,
   };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      swipeStartYCoordinate: undefined,
+    };
+  }
 
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown, false);
@@ -50,6 +58,21 @@ export default class MessageDialog extends React.Component {
     }
   };
 
+  handleTouchStart = (event) => {
+    this.setState({ swipeStartYCoordinate: event.changedTouches[0].screenY });
+  };
+
+  handleTouchEnd = (event) => {
+    const { handleClose } = this.props;
+    const { swipeStartYCoordinate } = this.state;
+
+    if (event.changedTouches[0].screenY - swipeStartYCoordinate >= 75) {
+      this.setState({ swipeStartYCoordinate: undefined }, () => handleClose());
+    } else {
+      this.setState({ swipeStartYCoordinate: undefined });
+    }
+  };
+
   render() {
     const {
       icon,
@@ -64,7 +87,7 @@ export default class MessageDialog extends React.Component {
 
     if (!isOpen) return null;
     return (
-      <>
+      <React.Fragment>
         <div
           className="lab-dialog-overlay"
           onClick={handleClose}
@@ -79,16 +102,29 @@ export default class MessageDialog extends React.Component {
             role="dialog"
             aria-modal="true"
           >
+            <button
+              type="button"
+              className="lab-dialog__mobile-close-button"
+              onClick={handleClose}
+              onTouchStart={this.handleTouchStart}
+              onTouchEnd={this.handleTouchEnd}
+            >
+              <Icon type="collapse-open" size="petit" />
+            </button>
             <div className="lab-dialog__header lab-dialog__header--message">
               <button type="button" onClick={handleClose}>
                 x
               </button>
             </div>
+
             <div className="lab-dialog__icon">
               <Icon type={icon} color="black-75" />
             </div>
+
             <div className="lab-dialog__title--message">{title}</div>
+
             <div className="lab-dialog__content--message">{content}</div>
+
             <div className="lab-dialog__footer">
               {outlineButtonProps ? (
                 <OutlineButton
@@ -106,7 +142,7 @@ export default class MessageDialog extends React.Component {
             </div>
           </div>
         </FocusTrap>
-      </>
+      </React.Fragment>
     );
   }
 }

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -20,6 +20,7 @@ export default class MessageDialog extends React.Component {
     isLarge: PropTypes.bool,
     handleClose: PropTypes.func,
     isOpen: PropTypes.bool,
+    isModal: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -27,6 +28,7 @@ export default class MessageDialog extends React.Component {
     isLarge: false,
     handleClose: () => {},
     isOpen: false,
+    isModal: false,
   };
 
   constructor(props) {
@@ -42,8 +44,8 @@ export default class MessageDialog extends React.Component {
   }
 
   componentDidUpdate() {
-    const { isOpen } = this.props;
-    document.body.style.overflow = isOpen ? "hidden" : "unset";
+    const { isOpen, isModal } = this.props;
+    document.body.style.overflow = isOpen && isModal ? "hidden" : "unset";
   }
 
   componentWillUnmount() {
@@ -83,16 +85,19 @@ export default class MessageDialog extends React.Component {
       isLarge,
       isOpen,
       handleClose,
+      isModal,
     } = this.props;
 
     if (!isOpen) return null;
     return (
       <React.Fragment>
-        <div
-          className="lab-dialog-overlay"
-          onClick={handleClose}
-          role="presentation"
-        />
+        {isModal ? (
+          <div
+            className="lab-dialog-overlay"
+            onClick={handleClose}
+            role="presentation"
+          />
+        ) : null}
         <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
           <div
             className={

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -109,7 +109,7 @@ export default class MessageDialog extends React.Component {
           >
             <button
               type="button"
-              className="lab-dialog__close-button--mobile"
+              className="lab-dialog__mobile-close-button"
               onClick={handleClose}
               onTouchStart={this.handleTouchStart}
               onTouchEnd={this.handleTouchEnd}

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -1,7 +1,26 @@
 import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "../Buttons";
 
 export default class MessageDialog extends React.Component {
   render() {
-    return <p>MessageDialog Component</p>;
+    return (
+      <div className="lab-dialog lab-dialog--message">
+        <div className="lab-dialog--message__header-wrapper">
+          <div className="lab-dialog__close-button--without-background">close button</div>
+        </div>
+        <div className="lab-dialog--message__icon">icon</div>
+        <div className="lab-dialog--message__title">title</div>
+        <div className="lab-dialog--message__content">content</div>
+        <div className="lab-dialog--message__button">
+          <Button
+            size="normal"
+            fullWidth={true}
+            text={"click me!"}
+            onClick={() => {}}
+          />
+        </div>
+      </div>
+    );
   }
 }

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -3,15 +3,25 @@ import PropTypes from "prop-types";
 import { Button } from "../Buttons";
 
 export default class MessageDialog extends React.Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
+  };
+
   render() {
+    const {
+      title,
+      content,
+    } = this.props;
+
     return (
       <div className="lab-dialog lab-dialog--message">
         <div className="lab-dialog--message__header-wrapper">
           <div className="lab-dialog__close-button--without-background">close button</div>
         </div>
         <div className="lab-dialog--message__icon">icon</div>
-        <div className="lab-dialog--message__title">title</div>
-        <div className="lab-dialog--message__content">content</div>
+        <div className="lab-dialog--message__title">{title}</div>
+        <div className="lab-dialog--message__content">{content}</div>
         <div className="lab-dialog--message__button">
           <Button
             size="normal"

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -13,15 +13,28 @@ export default class MessageDialog extends React.Component {
       onClick: PropTypes.func.isRequired,
     }).isRequired,
     isLarge: PropTypes.bool,
+    handleClose: PropTypes.func,
+    isOpen: PropTypes.bool,
   };
 
   static defaultProps = {
     isLarge: false,
-  }
+    handleClose: () => {},
+    isOpen: false,
+  };
 
   render() {
-    const { icon, title, content, buttonProps, isLarge } = this.props;
+    const {
+      icon,
+      title,
+      content,
+      buttonProps,
+      isLarge,
+      handleClose,
+      isOpen,
+    } = this.props;
 
+    if (!isOpen) return null;
     return (
       <div
         className={
@@ -30,7 +43,9 @@ export default class MessageDialog extends React.Component {
         }
       >
         <div className="lab-dialog__header lab-dialog__header--message">
-          <div>close button</div>
+          <button type="button" onClick={handleClose}>
+            x
+          </button>
         </div>
         <div className="lab-dialog__icon">
           <Icon type={icon} color="black-75" />

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -6,12 +6,17 @@ export default class MessageDialog extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
+    buttonProps: PropTypes.shape({
+      text: PropTypes.string.isRequired,
+      onClick: PropTypes.func.isRequired,
+    }).isRequired,
   };
 
   render() {
     const {
       title,
       content,
+      buttonProps,
     } = this.props;
 
     return (
@@ -26,8 +31,8 @@ export default class MessageDialog extends React.Component {
           <Button
             size="normal"
             fullWidth={true}
-            text={"click me!"}
-            onClick={() => {}}
+            text={buttonProps.text}
+            onClick={buttonProps.onClick}
           />
         </div>
       </div>

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import FocusTrap from "focus-trap-react";
 import { Button } from "../Buttons";
 import Icon from "../Icon";
 
@@ -23,13 +24,8 @@ export default class MessageDialog extends React.Component {
     isOpen: false,
   };
 
-  constructor(props) {
-    super(props);
-    this.escFunction = this.escFunction.bind(this);
-  }
-
   componentDidMount() {
-    document.addEventListener("keydown", this.escFunction, false);
+    document.addEventListener("keydown", this.handleKeyDown, false);
   }
 
   componentDidUpdate() {
@@ -38,15 +34,16 @@ export default class MessageDialog extends React.Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener("keydown", this.escFunction, false);
+    document.removeEventListener("keydown", this.handleKeyDown, false);
+    document.body.style.overflow = "unset";
   }
 
-  escFunction(event) {
+  handleKeyDown = (event) => {
     const { handleClose } = this.props;
     if (event.keyCode === 27) {
       handleClose();
     }
-  }
+  };
 
   render() {
     const {
@@ -55,37 +52,46 @@ export default class MessageDialog extends React.Component {
       content,
       buttonProps,
       isLarge,
-      handleClose,
       isOpen,
+      handleClose,
     } = this.props;
 
     if (!isOpen) return null;
     return (
-      <div className="lab-dialog__container" role="dialog" aria-modal="true">
+      <>
         <div
-          className={
-            `lab-dialog lab-dialog--message` +
-            `${isLarge ? ` lab-dialog--large` : ""}`
-          }
-        >
-          <div className="lab-dialog__header lab-dialog__header--message">
-            <button type="button" onClick={handleClose}>
-              x
-            </button>
+          className="lab-dialog-overlay"
+          onClick={handleClose}
+          role="presentation"
+        />
+        <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+          <div
+            className={
+              `lab-dialog lab-dialog--message` +
+              `${isLarge ? ` lab-dialog--large` : ""}`
+            }
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="lab-dialog__header lab-dialog__header--message">
+              <button type="button" onClick={handleClose}>
+                x
+              </button>
+            </div>
+            <div className="lab-dialog__icon">
+              <Icon type={icon} color="black-75" />
+            </div>
+            <div className="lab-dialog__title--message">{title}</div>
+            <div className="lab-dialog__content--message">{content}</div>
+            <Button
+              size="normal"
+              fullWidth
+              text={buttonProps.text}
+              onClick={buttonProps.onClick}
+            />
           </div>
-          <div className="lab-dialog__icon">
-            <Icon type={icon} color="black-75" />
-          </div>
-          <div className="lab-dialog__title--message">{title}</div>
-          <div className="lab-dialog__content--message">{content}</div>
-          <Button
-            size="normal"
-            fullWidth
-            text={buttonProps.text}
-            onClick={buttonProps.onClick}
-          />
-        </div>
-      </div>
+        </FocusTrap>
+      </>
     );
   }
 }

--- a/labsystem/src/Dialog/MessageDialog.js
+++ b/labsystem/src/Dialog/MessageDialog.js
@@ -15,30 +15,24 @@ export default class MessageDialog extends React.Component {
   };
 
   render() {
-    const {
-      icon,
-      title,
-      content,
-      buttonProps,
-    } = this.props;
+    const { icon, title, content, buttonProps } = this.props;
 
     return (
       <div className="lab-dialog lab-dialog--message">
         <div className="lab-dialog--message__header-wrapper">
-          <div className="lab-dialog__close-button--without-background">close button</div>
+          <div className="lab-dialog__close-button--without-background">
+            close button
+          </div>
         </div>
         <div className="lab-dialog--message__icon">
-          <Icon
-            type={icon}
-            color="black-75"
-          />
+          <Icon type={icon} color="black-75" />
         </div>
         <div className="lab-dialog--message__title">{title}</div>
         <div className="lab-dialog--message__content">{content}</div>
         <div className="lab-dialog--message__button">
           <Button
             size="normal"
-            fullWidth={true}
+            fullWidth
             text={buttonProps.text}
             onClick={buttonProps.onClick}
           />

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { TextButton, OutlineButton } from "../Buttons";
+import { Button, OutlineButton } from "../Buttons";
 
 export default class StandardDialog extends React.Component {
   static propTypes = {
@@ -20,7 +20,7 @@ export default class StandardDialog extends React.Component {
     const {
       title,
       content,
-      buttonProps, 
+      buttonProps,
       outlineButtonProps,
     } = this.props;
 
@@ -33,7 +33,7 @@ export default class StandardDialog extends React.Component {
         <p className="lab-dialog__content">{content}</p>
         <div className="lab-dialog__footer-wrapper">
           <div className="lab-dialog__optional-button">
-            { outlineButtonProps ? 
+            { outlineButtonProps ?
               <OutlineButton
                 size="normal"
                 text={outlineButtonProps.text}
@@ -42,9 +42,8 @@ export default class StandardDialog extends React.Component {
             : undefined }
           </div>
           <div className="lab-dialog__button">
-            <TextButton
+            <Button
               size="normal"
-              skin="dark"
               text={buttonProps.text}
               onClick={buttonProps.onClick}
             />

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -20,6 +20,7 @@ export default class StandardDialog extends React.Component {
     isLarge: PropTypes.bool,
     handleClose: PropTypes.func,
     isOpen: PropTypes.bool,
+    isModal: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -27,6 +28,7 @@ export default class StandardDialog extends React.Component {
     isLarge: false,
     handleClose: () => {},
     isOpen: false,
+    isModal: false,
   };
 
   constructor(props) {
@@ -42,8 +44,8 @@ export default class StandardDialog extends React.Component {
   }
 
   componentDidUpdate() {
-    const { isOpen } = this.props;
-    document.body.style.overflow = isOpen ? "hidden" : "unset";
+    const { isOpen, isModal } = this.props;
+    document.body.style.overflow = isOpen && isModal ? "hidden" : "unset";
   }
 
   componentWillUnmount() {
@@ -82,16 +84,19 @@ export default class StandardDialog extends React.Component {
       isLarge,
       isOpen,
       handleClose,
+      isModal,
     } = this.props;
 
     if (!isOpen) return null;
     return (
       <React.Fragment>
-        <div
-          className="lab-dialog-overlay"
-          onClick={handleClose}
-          role="presentation"
-        />
+        {isModal ? (
+          <div
+            className="lab-dialog-overlay"
+            onClick={handleClose}
+            role="presentation"
+          />
+        ) : null}
         <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
           <div
             className={

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 import FocusTrap from "focus-trap-react";
+
+import Icon from "../Icon";
 import { Button, OutlineButton } from "../Buttons";
 
 export default class StandardDialog extends React.Component {
@@ -27,6 +29,14 @@ export default class StandardDialog extends React.Component {
     isOpen: false,
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      swipeStartYCoordinate: undefined,
+    };
+  }
+
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown, false);
   }
@@ -45,6 +55,21 @@ export default class StandardDialog extends React.Component {
     const { handleClose } = this.props;
     if (event.keyCode === 27) {
       handleClose();
+    }
+  };
+
+  handleTouchStart = (event) => {
+    this.setState({ swipeStartYCoordinate: event.changedTouches[0].screenY });
+  };
+
+  handleTouchEnd = (event) => {
+    const { handleClose } = this.props;
+    const { swipeStartYCoordinate } = this.state;
+
+    if (event.changedTouches[0].screenY - swipeStartYCoordinate >= 75) {
+      this.setState({ swipeStartYCoordinate: undefined }, () => handleClose());
+    } else {
+      this.setState({ swipeStartYCoordinate: undefined });
     }
   };
 
@@ -76,13 +101,26 @@ export default class StandardDialog extends React.Component {
             role="dialog"
             aria-modal="true"
           >
+            <button
+              type="button"
+              className="lab-dialog__mobile-close-button"
+              style={{ width: "100%" }}
+              onClick={handleClose}
+              onTouchStart={this.handleTouchStart}
+              onTouchEnd={this.handleTouchEnd}
+            >
+              <Icon type="collapse-open" size="petit" />
+            </button>
+
             <div className="lab-dialog__header">
               <div className="lab-dialog__title">{title}</div>
               <button type="button" onClick={handleClose}>
                 x
               </button>
             </div>
+
             <p className="lab-dialog__content">{content}</p>
+
             <div className="lab-dialog__footer">
               {outlineButtonProps ? (
                 <OutlineButton

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -108,7 +108,7 @@ export default class StandardDialog extends React.Component {
           >
             <button
               type="button"
-              className="lab-dialog__close-button--mobile"
+              className="lab-dialog__mobile-close-button"
               onClick={handleClose}
               onTouchStart={this.handleTouchStart}
               onTouchEnd={this.handleTouchEnd}

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -38,30 +38,24 @@ export default class StandardDialog extends React.Component {
           `${isLarge ? ` lab-dialog--large` : ""}`
         }
       >
-        <div className="lab-dialog__standard-header">
-          <div className="lab-dialog__standard-title">{title}</div>
-          <div className="lab-dialog-close-button--with-background">
-            close button
-          </div>
+        <div className="lab-dialog__header">
+          <div className="lab-dialog__title">{title}</div>
+          <div>close button</div>
         </div>
-        <p className="lab-dialog__standard-content">{content}</p>
-        <div className="lab-dialog__standard-footer">
+        <p className="lab-dialog__content">{content}</p>
+        <div className="lab-dialog__footer">
           {outlineButtonProps ? (
-            <div className="lab-dialog__optional-button">
-              <OutlineButton
-                size="normal"
-                text={outlineButtonProps.text}
-                onClick={outlineButtonProps.onClick}
-              />
-            </div>
-          ) : undefined}
-          <div className="lab-dialog__button">
-            <Button
+            <OutlineButton
               size="normal"
-              text={buttonProps.text}
-              onClick={buttonProps.onClick}
+              text={outlineButtonProps.text}
+              onClick={outlineButtonProps.onClick}
             />
-          </div>
+          ) : undefined}
+          <Button
+            size="normal"
+            text={buttonProps.text}
+            onClick={buttonProps.onClick}
+          />
         </div>
       </div>
     );

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -1,9 +1,9 @@
 import React from "react";
 import PropTypes from "prop-types";
-import FocusTrap from "focus-trap-react";
 
 import Icon from "../Icon";
 import { Button, OutlineButton } from "../Buttons";
+import DialogWrapper from "./DialogWrapper";
 
 export default class StandardDialog extends React.Component {
   static propTypes = {
@@ -36,36 +36,16 @@ export default class StandardDialog extends React.Component {
 
     this.state = {
       swipeStartYCoordinate: undefined,
-      windowIsSmall: undefined,
     };
   }
 
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown, false);
-    window.addEventListener("resize", this.handleResize);
-    this.handleResize();
-    this.hideOverflow(this.checkHideOverflow());
-  }
-
-  componentDidUpdate() {
-    this.hideOverflow(this.checkHideOverflow());
   }
 
   componentWillUnmount() {
     document.removeEventListener("keydown", this.handleKeyDown, false);
-    window.removeEventListener("resize", this.handleResize, false);
-    document.body.style.overflow = "unset";
   }
-
-  checkHideOverflow = () => {
-    const { isOpen, isModal } = this.props;
-    const { windowIsSmall } = this.state;
-    return isOpen && (isModal || windowIsSmall);
-  };
-
-  hideOverflow = (shouldHideOverflow) => {
-    document.body.style.overflow = shouldHideOverflow ? "hidden" : "unset";
-  };
 
   handleKeyDown = (event) => {
     const { handleClose } = this.props;
@@ -89,10 +69,6 @@ export default class StandardDialog extends React.Component {
     }
   };
 
-  handleResize = () => {
-    this.setState({ windowIsSmall: window.outerWidth < 600 });
-  };
-
   render() {
     const {
       title,
@@ -101,70 +77,64 @@ export default class StandardDialog extends React.Component {
       outlineButtonProps,
       isLarge,
       isOpen,
-      handleClose,
       isModal,
+      handleClose,
     } = this.props;
-    const { windowIsSmall } = this.state;
 
     if (!isOpen) return null;
     return (
-      <React.Fragment>
-        {isModal || windowIsSmall ? (
-          <div
-            className="lab-dialog-overlay"
+      <DialogWrapper
+        handleClose={handleClose}
+        isOpen={isOpen}
+        isModal={isModal}
+      >
+        <div
+          className={
+            `lab-dialog lab-dialog--standard` +
+            `${isLarge ? ` lab-dialog--large` : ""}`
+          }
+          role="dialog"
+          aria-modal="true"
+        >
+          <button
+            type="button"
+            className="lab-dialog__mobile-close-button"
             onClick={handleClose}
-            role="presentation"
-          />
-        ) : null}
-        <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
-          <div
-            className={
-              `lab-dialog lab-dialog--standard` +
-              `${isLarge ? ` lab-dialog--large` : ""}`
-            }
-            role="dialog"
-            aria-modal="true"
+            onTouchStart={this.handleTouchStart}
+            onTouchEnd={this.handleTouchEnd}
           >
+            <Icon type="collapse-open" size="petit" />
+          </button>
+
+          <div className="lab-dialog__header">
+            <div className="lab-dialog__title">{title}</div>
             <button
+              className="lab-dialog__close-button"
               type="button"
-              className="lab-dialog__mobile-close-button"
               onClick={handleClose}
-              onTouchStart={this.handleTouchStart}
-              onTouchEnd={this.handleTouchEnd}
             >
-              <Icon type="collapse-open" size="petit" />
+              <Icon type="remove" />
             </button>
-
-            <div className="lab-dialog__header">
-              <div className="lab-dialog__title">{title}</div>
-              <button
-                className="lab-dialog__close-button"
-                type="button"
-                onClick={handleClose}
-              >
-                <Icon type="remove" />
-              </button>
-            </div>
-
-            <p className="lab-dialog__content">{content}</p>
-
-            <div className="lab-dialog__footer">
-              {outlineButtonProps ? (
-                <OutlineButton
-                  size="normal"
-                  text={outlineButtonProps.text}
-                  onClick={outlineButtonProps.onClick}
-                />
-              ) : undefined}
-              <Button
-                size="normal"
-                text={buttonProps.text}
-                onClick={buttonProps.onClick}
-              />
-            </div>
           </div>
-        </FocusTrap>
-      </React.Fragment>
+
+          <p className="lab-dialog__content">{content}</p>
+
+          <div className="lab-dialog__footer">
+            {outlineButtonProps ? (
+              <OutlineButton
+                size="normal"
+                text={outlineButtonProps.text}
+                onClick={outlineButtonProps.onClick}
+              />
+            ) : undefined}
+            <Button
+              size="normal"
+              text={buttonProps.text}
+              onClick={buttonProps.onClick}
+            />
+          </div>
+        </div>
+      </DialogWrapper>
     );
   }
 }

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -9,11 +9,11 @@ export default class StandardDialog extends React.Component {
   static propTypes = {
     title: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
-    buttonProps: PropTypes.shape({
+    buttonProps: PropTypes.exact({
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }).isRequired,
-    outlineButtonProps: PropTypes.shape({
+    outlineButtonProps: PropTypes.exact({
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }),
@@ -86,7 +86,7 @@ export default class StandardDialog extends React.Component {
 
     if (!isOpen) return null;
     return (
-      <>
+      <React.Fragment>
         <div
           className="lab-dialog-overlay"
           onClick={handleClose}
@@ -104,7 +104,6 @@ export default class StandardDialog extends React.Component {
             <button
               type="button"
               className="lab-dialog__mobile-close-button"
-              style={{ width: "100%" }}
               onClick={handleClose}
               onTouchStart={this.handleTouchStart}
               onTouchEnd={this.handleTouchEnd}
@@ -115,7 +114,7 @@ export default class StandardDialog extends React.Component {
             <div className="lab-dialog__header">
               <div className="lab-dialog__title">{title}</div>
               <button type="button" onClick={handleClose}>
-                x
+                <Icon type="remove" />
               </button>
             </div>
 
@@ -137,7 +136,7 @@ export default class StandardDialog extends React.Component {
             </div>
           </div>
         </FocusTrap>
-      </>
+      </React.Fragment>
     );
   }
 }

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -108,7 +108,7 @@ export default class StandardDialog extends React.Component {
           >
             <button
               type="button"
-              className="lab-dialog__mobile-close-button"
+              className="lab-dialog__close-button--mobile"
               onClick={handleClose}
               onTouchStart={this.handleTouchStart}
               onTouchEnd={this.handleTouchEnd}
@@ -118,7 +118,11 @@ export default class StandardDialog extends React.Component {
 
             <div className="lab-dialog__header">
               <div className="lab-dialog__title">{title}</div>
-              <button type="button" onClick={handleClose}>
+              <button
+                className="lab-dialog__close-button"
+                type="button"
+                onClick={handleClose}
+              >
                 <Icon type="remove" />
               </button>
             </div>

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -26,13 +26,13 @@ export default class StandardDialog extends React.Component {
 
     return (
       <div className="lab-dialog lab-dialog--standard">
-        <div className="lab-dialog__header-wrapper">
-          <div className="lab-dialog__title">{title}</div>
-          <div className="lab-dialog__close-button">close button</div>
+        <div className="lab-dialog--standard__header-wrapper">
+          <div className="lab-dialog--standard__title">{title}</div>
+          <div className="lab-dialog__close-button--with-background">close button</div>
         </div>
-        <p className="lab-dialog__content">{content}</p>
-        <div className="lab-dialog__footer-wrapper">
-          <div className="lab-dialog__optional-button">
+        <p className="lab-dialog--standard__content">{content}</p>
+        <div className="lab-dialog--standard__footer-wrapper">
+          <div className="lab-dialog--standard__optional-button">
             { outlineButtonProps ?
               <OutlineButton
                 size="normal"
@@ -41,7 +41,7 @@ export default class StandardDialog extends React.Component {
               />
             : undefined }
           </div>
-          <div className="lab-dialog__button">
+          <div className="lab-dialog--standard__button">
             <Button
               size="normal"
               text={buttonProps.text}

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -15,11 +15,15 @@ export default class StandardDialog extends React.Component {
       onClick: PropTypes.func.isRequired,
     }),
     isLarge: PropTypes.bool,
+    handleClose: PropTypes.func,
+    isOpen: PropTypes.bool,
   };
 
   static defaultProps = {
     outlineButtonProps: undefined,
     isLarge: false,
+    handleClose: () => {},
+    isOpen: false,
   };
 
   render() {
@@ -29,8 +33,11 @@ export default class StandardDialog extends React.Component {
       buttonProps,
       outlineButtonProps,
       isLarge,
+      isOpen,
+      handleClose,
     } = this.props;
 
+    if (!isOpen) return null;
     return (
       <div
         className={
@@ -40,7 +47,9 @@ export default class StandardDialog extends React.Component {
       >
         <div className="lab-dialog__header">
           <div className="lab-dialog__title">{title}</div>
-          <div>close button</div>
+          <button type="button" onClick={handleClose}>
+            x
+          </button>
         </div>
         <p className="lab-dialog__content">{content}</p>
         <div className="lab-dialog__footer">

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -17,10 +17,7 @@ export default class StandardDialog extends React.Component {
   };
 
   static defaultProps = {
-    outlineButtonProps: {
-      text: "",
-      onClick: () => {},
-    },
+    outlineButtonProps: undefined,
   };
 
   render() {
@@ -28,16 +25,16 @@ export default class StandardDialog extends React.Component {
 
     return (
       <div className="lab-dialog lab-dialog--standard">
-        <div className="lab-dialog--standard__header-wrapper">
-          <div className="lab-dialog--standard__title">{title}</div>
-          <div className="lab-dialog__close-button--with-background">
+        <div className="lab-dialog__standard-header">
+          <div className="lab-dialog__standard-title">{title}</div>
+          <div className="lab-dialog-close-button--with-background">
             close button
           </div>
         </div>
-        <p className="lab-dialog--standard__content">{content}</p>
-        <div className="lab-dialog--standard__footer-wrapper">
+        <p className="lab-dialog__standard-content">{content}</p>
+        <div className="lab-dialog__standard-footer">
           {outlineButtonProps ? (
-            <div className="lab-dialog--standard__optional-button">
+            <div className="lab-dialog__optional-button">
               <OutlineButton
                 size="normal"
                 text={outlineButtonProps.text}
@@ -45,7 +42,7 @@ export default class StandardDialog extends React.Component {
               />
             </div>
           ) : undefined}
-          <div className="lab-dialog--standard__button">
+          <div className="lab-dialog__button">
             <Button
               size="normal"
               text={buttonProps.text}

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import TextButton from "../Buttons/TextButton";
+import { TextButton } from "../Buttons";
 
 export default class StandardDialog extends React.Component {
   static propTypes = {
@@ -10,34 +10,33 @@ export default class StandardDialog extends React.Component {
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }).isRequired,
-  }
-
-  button = () => {
-    const {
-      buttonProps: { text },
-    } = this.props;
-    return <TextButton size="normal" skin="dark" text={text} />;
-  };
-
-  handleClick = (e) => {
-    const {
-      buttonProps: { onClick },
-    } = this.props;
-    onClick(e);
   };
 
   render() {
-    const { title, content } = this.props;
+    const {
+      title,
+      content,
+      buttonProps: { text, onClick },
+    } = this.props;
+
     return (
-      <div className={`lab-dialog lab-dialog--standard`}>
-        <span className="lab-dialog__title">{title}</span>
-        <span className="lab-dialog__content">{content}</span>
-        <span
-          className="lab-dialog__button"
-          onClick={this.handleClick}
-        >
-          {this.button()}
-        </span>
+      <div className="lab-dialog lab-dialog--standard">
+        <div className="lab-dialog__header-wrapper">
+          <div className="lab-dialog__title">{title}</div>
+          <div className="lab-dialog__close-button">close button</div>
+        </div>
+        <p className="lab-dialog__content">{content}</p>
+        <div className="lab-dialog__footer-wrapper">
+          <div className="lab-dialog__optional-button">optional button</div>
+          <div className="lab-dialog__button">
+            <TextButton
+              size="normal"
+              skin="dark"
+              text={text}
+              onClick={onClick}
+            />
+          </div>
+        </div>
       </div>
     );
   }

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import FocusTrap from "focus-trap-react";
 import { Button, OutlineButton } from "../Buttons";
 
 export default class StandardDialog extends React.Component {
@@ -26,13 +27,8 @@ export default class StandardDialog extends React.Component {
     isOpen: false,
   };
 
-  constructor(props) {
-    super(props);
-    this.escFunction = this.escFunction.bind(this);
-  }
-
   componentDidMount() {
-    document.addEventListener("keydown", this.escFunction, false);
+    document.addEventListener("keydown", this.handleKeyDown, false);
   }
 
   componentDidUpdate() {
@@ -41,15 +37,16 @@ export default class StandardDialog extends React.Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener("keydown", this.escFunction, false);
+    document.removeEventListener("keydown", this.handleKeyDown, false);
+    document.body.style.overflow = "unset";
   }
 
-  escFunction(event) {
+  handleKeyDown = (event) => {
     const { handleClose } = this.props;
     if (event.keyCode === 27) {
       handleClose();
     }
-  }
+  };
 
   render() {
     const {
@@ -64,36 +61,45 @@ export default class StandardDialog extends React.Component {
 
     if (!isOpen) return null;
     return (
-      <div className="lab-dialog__container" role="dialog" aria-modal="true">
+      <>
         <div
-          className={
-            `lab-dialog lab-dialog--standard` +
-            `${isLarge ? ` lab-dialog--large` : ""}`
-          }
-        >
-          <div className="lab-dialog__header">
-            <div className="lab-dialog__title">{title}</div>
-            <button type="button" onClick={handleClose}>
-              x
-            </button>
-          </div>
-          <p className="lab-dialog__content">{content}</p>
-          <div className="lab-dialog__footer">
-            {outlineButtonProps ? (
-              <OutlineButton
+          className="lab-dialog-overlay"
+          onClick={handleClose}
+          role="presentation"
+        />
+        <FocusTrap focusTrapOptions={{ allowOutsideClick: true }}>
+          <div
+            className={
+              `lab-dialog lab-dialog--standard` +
+              `${isLarge ? ` lab-dialog--large` : ""}`
+            }
+            role="dialog"
+            aria-modal="true"
+          >
+            <div className="lab-dialog__header">
+              <div className="lab-dialog__title">{title}</div>
+              <button type="button" onClick={handleClose}>
+                x
+              </button>
+            </div>
+            <p className="lab-dialog__content">{content}</p>
+            <div className="lab-dialog__footer">
+              {outlineButtonProps ? (
+                <OutlineButton
+                  size="normal"
+                  text={outlineButtonProps.text}
+                  onClick={outlineButtonProps.onClick}
+                />
+              ) : undefined}
+              <Button
                 size="normal"
-                text={outlineButtonProps.text}
-                onClick={outlineButtonProps.onClick}
+                text={buttonProps.text}
+                onClick={buttonProps.onClick}
               />
-            ) : undefined}
-            <Button
-              size="normal"
-              text={buttonProps.text}
-              onClick={buttonProps.onClick}
-            />
+            </div>
           </div>
-        </div>
-      </div>
+        </FocusTrap>
+      </>
     );
   }
 }

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -36,15 +36,15 @@ export default class StandardDialog extends React.Component {
         </div>
         <p className="lab-dialog--standard__content">{content}</p>
         <div className="lab-dialog--standard__footer-wrapper">
-          <div className="lab-dialog--standard__optional-button">
-            {outlineButtonProps ? (
+          {outlineButtonProps ? (
+            <div className="lab-dialog--standard__optional-button">
               <OutlineButton
                 size="normal"
                 text={outlineButtonProps.text}
                 onClick={outlineButtonProps.onClick}
               />
-            ) : undefined}
-          </div>
+            </div>
+          ) : undefined}
           <div className="lab-dialog--standard__button">
             <Button
               size="normal"

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -36,22 +36,36 @@ export default class StandardDialog extends React.Component {
 
     this.state = {
       swipeStartYCoordinate: undefined,
+      windowIsSmall: undefined,
     };
   }
 
   componentDidMount() {
     document.addEventListener("keydown", this.handleKeyDown, false);
+    window.addEventListener("resize", this.handleResize);
+    this.handleResize();
+    this.hideOverflow(this.checkHideOverflow());
   }
 
   componentDidUpdate() {
-    const { isOpen, isModal } = this.props;
-    document.body.style.overflow = isOpen && isModal ? "hidden" : "unset";
+    this.hideOverflow(this.checkHideOverflow());
   }
 
   componentWillUnmount() {
     document.removeEventListener("keydown", this.handleKeyDown, false);
+    window.removeEventListener("resize", this.handleResize, false);
     document.body.style.overflow = "unset";
   }
+
+  checkHideOverflow = () => {
+    const { isOpen, isModal } = this.props;
+    const { windowIsSmall } = this.state;
+    return isOpen && (isModal || windowIsSmall);
+  };
+
+  hideOverflow = (shouldHideOverflow) => {
+    document.body.style.overflow = shouldHideOverflow ? "hidden" : "unset";
+  };
 
   handleKeyDown = (event) => {
     const { handleClose } = this.props;
@@ -75,6 +89,10 @@ export default class StandardDialog extends React.Component {
     }
   };
 
+  handleResize = () => {
+    this.setState({ windowIsSmall: window.outerWidth < 600 });
+  };
+
   render() {
     const {
       title,
@@ -86,11 +104,12 @@ export default class StandardDialog extends React.Component {
       handleClose,
       isModal,
     } = this.props;
+    const { windowIsSmall } = this.state;
 
     if (!isOpen) return null;
     return (
       <React.Fragment>
-        {isModal ? (
+        {isModal || windowIsSmall ? (
           <div
             className="lab-dialog-overlay"
             onClick={handleClose}

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -1,7 +1,44 @@
 import React from "react";
+import PropTypes from "prop-types";
+import TextButton from "../Buttons/TextButton";
 
 export default class StandardDialog extends React.Component {
+  static propTypes = {
+    title: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
+    buttonProps: PropTypes.shape({
+      text: PropTypes.string.isRequired,
+      onClick: PropTypes.func.isRequired,
+    }).isRequired,
+  }
+
+  button = () => {
+    const {
+      buttonProps: { text },
+    } = this.props;
+    return <TextButton size="normal" skin="dark" text={text} />;
+  };
+
+  handleClick = (e) => {
+    const {
+      buttonProps: { onClick },
+    } = this.props;
+    onClick(e);
+  };
+
   render() {
-    return <h1>Standard Dialog Component</h1>;
+    const { title, content } = this.props;
+    return (
+      <div className={`lab-dialog lab-dialog--standard`}>
+        <span className="lab-dialog__title">{title}</span>
+        <span className="lab-dialog__content">{content}</span>
+        <span
+          className="lab-dialog__button"
+          onClick={this.handleClick}
+        >
+          {this.button()}
+        </span>
+      </div>
+    );
   }
 }

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -26,9 +26,29 @@ export default class StandardDialog extends React.Component {
     isOpen: false,
   };
 
+  constructor(props) {
+    super(props);
+    this.escFunction = this.escFunction.bind(this);
+  }
+
+  componentDidMount() {
+    document.addEventListener("keydown", this.escFunction, false);
+  }
+
   componentDidUpdate() {
     const { isOpen } = this.props;
     document.body.style.overflow = isOpen ? "hidden" : "unset";
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.escFunction, false);
+  }
+
+  escFunction(event) {
+    const { handleClose } = this.props;
+    if (event.keyCode === 27) {
+      handleClose();
+    }
   }
 
   render() {
@@ -44,13 +64,13 @@ export default class StandardDialog extends React.Component {
 
     if (!isOpen) return null;
     return (
-      <div
-        className={
-          `lab-dialog lab-dialog--standard` +
-          `${isLarge ? ` lab-dialog--large` : ""}`
-        }
-      >
-        <div className="lab-dialog lab-dialog__container">
+      <div className="lab-dialog__container" role="dialog" aria-modal="true">
+        <div
+          className={
+            `lab-dialog lab-dialog--standard` +
+            `${isLarge ? ` lab-dialog--large` : ""}`
+          }
+        >
           <div className="lab-dialog__header">
             <div className="lab-dialog__title">{title}</div>
             <button type="button" onClick={handleClose}>

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { TextButton } from "../Buttons";
+import { TextButton, OutlineButton } from "../Buttons";
 
 export default class StandardDialog extends React.Component {
   static propTypes = {
@@ -10,13 +10,18 @@ export default class StandardDialog extends React.Component {
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }).isRequired,
+    outlineButtonProps: PropTypes.shape({
+      text: PropTypes.string.isRequired,
+      onClick: PropTypes.func.isRequired,
+    }),
   };
 
   render() {
     const {
       title,
       content,
-      buttonProps: { text, onClick },
+      buttonProps, 
+      outlineButtonProps,
     } = this.props;
 
     return (
@@ -27,13 +32,21 @@ export default class StandardDialog extends React.Component {
         </div>
         <p className="lab-dialog__content">{content}</p>
         <div className="lab-dialog__footer-wrapper">
-          <div className="lab-dialog__optional-button">optional button</div>
+          <div className="lab-dialog__optional-button">
+            { outlineButtonProps ? 
+              <OutlineButton
+                size="normal"
+                text={outlineButtonProps.text}
+                onClick={outlineButtonProps.onClick}
+              />
+            : undefined }
+          </div>
           <div className="lab-dialog__button">
             <TextButton
               size="normal"
               skin="dark"
-              text={text}
-              onClick={onClick}
+              text={buttonProps.text}
+              onClick={buttonProps.onClick}
             />
           </div>
         </div>

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class StandardDialog extends React.Component {
+  render() {
+    return <h1>Standard Dialog Component</h1>;
+  }
+}

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -16,30 +16,34 @@ export default class StandardDialog extends React.Component {
     }),
   };
 
+  static defaultProps = {
+    outlineButtonProps: {
+      text: "",
+      onClick: () => {},
+    },
+  };
+
   render() {
-    const {
-      title,
-      content,
-      buttonProps,
-      outlineButtonProps,
-    } = this.props;
+    const { title, content, buttonProps, outlineButtonProps } = this.props;
 
     return (
       <div className="lab-dialog lab-dialog--standard">
         <div className="lab-dialog--standard__header-wrapper">
           <div className="lab-dialog--standard__title">{title}</div>
-          <div className="lab-dialog__close-button--with-background">close button</div>
+          <div className="lab-dialog__close-button--with-background">
+            close button
+          </div>
         </div>
         <p className="lab-dialog--standard__content">{content}</p>
         <div className="lab-dialog--standard__footer-wrapper">
           <div className="lab-dialog--standard__optional-button">
-            { outlineButtonProps ?
+            {outlineButtonProps ? (
               <OutlineButton
                 size="normal"
                 text={outlineButtonProps.text}
                 onClick={outlineButtonProps.onClick}
               />
-            : undefined }
+            ) : undefined}
           </div>
           <div className="lab-dialog--standard__button">
             <Button

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -26,6 +26,11 @@ export default class StandardDialog extends React.Component {
     isOpen: false,
   };
 
+  componentDidUpdate() {
+    const { isOpen } = this.props;
+    document.body.style.overflow = isOpen ? "hidden" : "unset";
+  }
+
   render() {
     const {
       title,
@@ -45,26 +50,28 @@ export default class StandardDialog extends React.Component {
           `${isLarge ? ` lab-dialog--large` : ""}`
         }
       >
-        <div className="lab-dialog__header">
-          <div className="lab-dialog__title">{title}</div>
-          <button type="button" onClick={handleClose}>
-            x
-          </button>
-        </div>
-        <p className="lab-dialog__content">{content}</p>
-        <div className="lab-dialog__footer">
-          {outlineButtonProps ? (
-            <OutlineButton
+        <div className="lab-dialog lab-dialog__container">
+          <div className="lab-dialog__header">
+            <div className="lab-dialog__title">{title}</div>
+            <button type="button" onClick={handleClose}>
+              x
+            </button>
+          </div>
+          <p className="lab-dialog__content">{content}</p>
+          <div className="lab-dialog__footer">
+            {outlineButtonProps ? (
+              <OutlineButton
+                size="normal"
+                text={outlineButtonProps.text}
+                onClick={outlineButtonProps.onClick}
+              />
+            ) : undefined}
+            <Button
               size="normal"
-              text={outlineButtonProps.text}
-              onClick={outlineButtonProps.onClick}
+              text={buttonProps.text}
+              onClick={buttonProps.onClick}
             />
-          ) : undefined}
-          <Button
-            size="normal"
-            text={buttonProps.text}
-            onClick={buttonProps.onClick}
-          />
+          </div>
         </div>
       </div>
     );

--- a/labsystem/src/Dialog/StandardDialog.js
+++ b/labsystem/src/Dialog/StandardDialog.js
@@ -14,17 +14,30 @@ export default class StandardDialog extends React.Component {
       text: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
     }),
+    isLarge: PropTypes.bool,
   };
 
   static defaultProps = {
     outlineButtonProps: undefined,
+    isLarge: false,
   };
 
   render() {
-    const { title, content, buttonProps, outlineButtonProps } = this.props;
+    const {
+      title,
+      content,
+      buttonProps,
+      outlineButtonProps,
+      isLarge,
+    } = this.props;
 
     return (
-      <div className="lab-dialog lab-dialog--standard">
+      <div
+        className={
+          `lab-dialog lab-dialog--standard` +
+          `${isLarge ? ` lab-dialog--large` : ""}`
+        }
+      >
         <div className="lab-dialog__standard-header">
           <div className="lab-dialog__standard-title">{title}</div>
           <div className="lab-dialog-close-button--with-background">

--- a/labsystem/src/Dialog/index.js
+++ b/labsystem/src/Dialog/index.js
@@ -1,1 +1,2 @@
 export { default as StandardDialog } from "./StandardDialog";
+export { default as MessageDialog } from "./MessageDialog";

--- a/labsystem/src/Dialog/index.js
+++ b/labsystem/src/Dialog/index.js
@@ -1,0 +1,1 @@
+export { default as StandardDialog } from "./StandardDialog";

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -30,7 +30,17 @@ export default class DialogPlayground extends React.Component {
       selectedButtonResponseText: "Button has been clicked!",
       selectedOutlineButtonResponseText: "OutlineButton has been clicked!",
       modalIsOpen: false,
+      windowIsSmall: undefined,
     };
+  }
+
+  componentDidMount() {
+    window.addEventListener("resize", this.handleResize);
+    this.handleResize();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener("resize", this.handleResize, false);
   }
 
   handleCurrentComponentChange = (e) => {
@@ -64,6 +74,10 @@ export default class DialogPlayground extends React.Component {
 
   handleModalClose = () => {
     this.setState({ modalIsOpen: false });
+  };
+
+  handleResize = () => {
+    this.setState({ windowIsSmall: window.outerWidth < 600 });
   };
 
   renderCurrentComponent = () => {
@@ -122,6 +136,7 @@ export default class DialogPlayground extends React.Component {
       selectedButtonText,
       selectedOutlineButtonText,
       selectedIsModal,
+      windowIsSmall,
     } = this.state;
 
     return (
@@ -195,15 +210,20 @@ export default class DialogPlayground extends React.Component {
           </span>
           <br />
 
-          <span className="lab-playground__item">
-            <Checkbox
-              id="selectedIsModal"
-              onChange={this.handleBoolPropChange}
-              checked={selectedIsModal}
-              label="isModal"
-            />
-          </span>
-          <br />
+          {!windowIsSmall ? (
+            <>
+              <span className="lab-playground__item">
+                <Checkbox
+                  name="selectedIsModal"
+                  id="selectedIsModal"
+                  onChange={this.handleBoolPropChange}
+                  checked={selectedIsModal}
+                  label="isModal"
+                />
+              </span>
+              <br />
+            </>
+          ) : null}
 
           {currentComponent === "MessageDialog" ? (
             <span className="lab-playground__item">

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -11,20 +11,18 @@ export default class DialogPlayground extends React.Component {
       selectedTitle: "edit me",
       selectedContent: "edit me",
       selectedButtonText: "edit me",
-      selectedButtonResponseText: "edit me",
       hasOutlineButton: false,
       selectedOutlineButtonText: "edit me",
-      selectedOutlineButtonResponseText: "edit me",
     };
 
     this.state = {
       selectedTitle: this.initialState.selectedTitle,
       selectedContent: this.initialState.selectedContent,
       selectedButtonText: this.initialState.selectedButtonText,
-      selectedButtonResponseText: this.initialState.selectedButtonResponseText,
       hasOutlineButton: this.initialState.hasOutlineButton,
       selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
-      selectedOutlineButtonResponseText: this.initialState.selectedOutlineButtonResponseText,
+      selectedButtonResponseText: "Button has been clicked!",
+      selectedOutlineButtonResponseText: "OutlineButton has been clicked!",
     };
   }
 
@@ -33,7 +31,6 @@ export default class DialogPlayground extends React.Component {
     this.setState({
       [id]: checked,
       selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
-      selectedOutlineButtonResponseText: this.initialState.selectedOutlineButtonResponseText,
     });
   };
 
@@ -47,9 +44,9 @@ export default class DialogPlayground extends React.Component {
       selectedTitle,
       selectedContent,
       selectedButtonText,
-      selectedButtonResponseText,
       hasOutlineButton,
       selectedOutlineButtonText,
+      selectedButtonResponseText,
       selectedOutlineButtonResponseText,
     } = this.state;
 
@@ -128,19 +125,6 @@ export default class DialogPlayground extends React.Component {
           <br />
 
           <span className="lab-playground__item">
-            <label htmlFor="selectedButtonResponseText">
-              <strong>buttonResponseText:</strong>
-              <br />
-              <input
-                id="selectedButtonResponseText"
-                onChange={this.handleTextPropChange}
-                placeholder="Insert button response text"
-              />
-            </label>
-          </span>
-          <br />
-
-          <span className="lab-playground__item">
             <label htmlFor="">
               <strong>hasOutlineButton: </strong>
               <input
@@ -153,7 +137,6 @@ export default class DialogPlayground extends React.Component {
           <br />
 
           { hasOutlineButton ?
-            <>
             <span className="lab-playground__item">
               <label htmlFor="selectedOutlineButtonText">
                 <strong>selectedOutlineButtonText:</strong>
@@ -165,23 +148,7 @@ export default class DialogPlayground extends React.Component {
                 />
               </label>
             </span>
-            <br />
-
-            <span className="lab-playground__item">
-              <label htmlFor="selectedOutlineButtonResponseText">
-                <strong>selectedOutlineButtonResponseText:</strong>
-                <br />
-                <input
-                  id="selectedOutlineButtonResponseText"
-                  onChange={this.handleTextPropChange}
-                  placeholder="Insert outline button response text"
-                />
-              </label>
-            </span>
-            <br />
-            </>
           : undefined }
-
         </div>
       </div>
     );

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -1,6 +1,9 @@
 import React from "react";
 
+import TextInput from "../labsystem/src/Input/TextInput";
+import Checkbox from "../labsystem/src/Checkbox";
 import { StandardDialog, MessageDialog } from "../labsystem/src/Dialog";
+import { Button } from "../labsystem/src/Buttons";
 import { iconOptions } from "./assets";
 
 export default class DialogPlayground extends React.Component {
@@ -80,41 +83,32 @@ export default class DialogPlayground extends React.Component {
     const Component = availableComponents[currentComponent];
 
     return (
-      <>
+      <React.Fragment>
         <h4>
           <strong>{currentComponent}</strong>
         </h4>
-        <div
-          className="container"
-          ref={(node) => {
-            this.node = node;
+        <Button text="Show Modal" onClick={this.showModal} />
+        <Component
+          icon={selectedIcon}
+          title={selectedTitle}
+          content={selectedContent}
+          handleClose={this.handleModalClose}
+          isOpen={modalIsOpen}
+          isModal={selectedIsModal}
+          buttonProps={{
+            text: selectedButtonText,
+            onClick: () => alert(selectedButtonResponseText),
           }}
-        >
-          <button type="button" onClick={this.showModal}>
-            show Modal
-          </button>
-          <Component
-            icon={selectedIcon}
-            title={selectedTitle}
-            content={selectedContent}
-            handleClose={this.handleModalClose}
-            isOpen={modalIsOpen}
-            isModal={selectedIsModal}
-            buttonProps={{
-              text: selectedButtonText,
-              onClick: () => alert(selectedButtonResponseText),
-            }}
-            outlineButtonProps={
-              hasOutlineButton
-                ? {
-                    text: selectedOutlineButtonText,
-                    onClick: () => alert(selectedOutlineButtonResponseText),
-                  }
-                : undefined
-            }
-          />
-        </div>
-      </>
+          outlineButtonProps={
+            hasOutlineButton
+              ? {
+                  text: selectedOutlineButtonText,
+                  onClick: () => alert(selectedOutlineButtonResponseText),
+                }
+              : undefined
+          }
+        />
+      </React.Fragment>
     );
   };
 
@@ -155,16 +149,12 @@ export default class DialogPlayground extends React.Component {
           <br />
 
           <span className="lab-playground__item">
-            <label htmlFor="selectedTitle">
-              <strong>title:</strong>
-              <br />
-              <input
-                id="selectedTitle"
-                onChange={this.handleTextPropChange}
-                placeholder="Insert title"
-                value={selectedTitle}
-              />
-            </label>
+            <TextInput
+              id="selectedTitle"
+              onChange={this.handleTextPropChange}
+              value={selectedTitle}
+              label="title"
+            />
           </span>
           <br />
 
@@ -175,7 +165,6 @@ export default class DialogPlayground extends React.Component {
               <textarea
                 id="selectedContent"
                 onChange={this.handleTextPropChange}
-                placeholder="Insert content"
                 value={selectedContent}
                 style={{
                   width: "100%",
@@ -188,57 +177,44 @@ export default class DialogPlayground extends React.Component {
           <br />
 
           <span className="lab-playground__item">
-            <label htmlFor="selectedButtonText">
-              <strong>buttonText:</strong>
-              <br />
-              <input
-                id="selectedButtonText"
-                onChange={this.handleTextPropChange}
-                placeholder="Insert button text"
-                value={selectedButtonText}
-              />
-            </label>
+            <TextInput
+              id="selectedButtonText"
+              onChange={this.handleTextPropChange}
+              placeholder="Insert button text"
+              value={selectedButtonText}
+              label="button text:"
+            />
           </span>
           <br />
 
           <span className="lab-playground__item">
-            <label htmlFor="selectedIsModal">
-              <strong>selectedIsModal: </strong>
-              <input
-                id="selectedIsModal"
-                type="checkbox"
-                onChange={this.handleBoolPropChange}
-                checked={selectedIsModal}
-              />
-            </label>
+            <Checkbox
+              id="selectedIsModal"
+              onChange={this.handleBoolPropChange}
+              checked={selectedIsModal}
+              label="is modal"
+            />
           </span>
           <br />
 
           <span className="lab-playground__item">
-            <label htmlFor="hasOutlineButton">
-              <strong>hasOutlineButton: </strong>
-              <input
-                id="hasOutlineButton"
-                type="checkbox"
-                onChange={this.handleBoolPropChange}
-                checked={hasOutlineButton}
-              />
-            </label>
+            <Checkbox
+              id="hasOutlineButton"
+              onChange={this.handleBoolPropChange}
+              checked={hasOutlineButton}
+              label="has outline button"
+            />
           </span>
           <br />
 
           {hasOutlineButton ? (
             <span className="lab-playground__item">
-              <label htmlFor="selectedOutlineButtonText">
-                <strong>selectedOutlineButtonText:</strong>
-                <br />
-                <input
-                  id="selectedOutlineButtonText"
-                  onChange={this.handleTextPropChange}
-                  placeholder="Insert outline button text"
-                  value={selectedOutlineButtonText}
-                />
-              </label>
+              <TextInput
+                id="selectedOutlineButtonText"
+                onChange={this.handleTextPropChange}
+                value={selectedOutlineButtonText}
+                label="outline button text:"
+              />
               <br />
             </span>
           ) : null}

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -9,10 +9,12 @@ export default class DialogPlayground extends React.Component {
     super(props);
     this.initialState = {
       selectedTitle: "edit me",
+      selectedContent: "edit me",
     };
 
     this.state = {
       selectedTitle: this.initialState.selectedTitle,
+      selectedContent: this.initialState.selectedContent,
     };
   }
 
@@ -22,14 +24,14 @@ export default class DialogPlayground extends React.Component {
   };
 
   renderCurrentComponent = () => {
-    const { selectedTitle } = this.state;
+    const { selectedTitle, selectedContent } = this.state;
 
     return (
       <>
         <h4><strong>Standard Dialog</strong></h4>
         <StandardDialog
           title={selectedTitle}
-          content="This is a generic content."
+          content={selectedContent}
           buttonProps={{
             text: "click me!",
             onClick: () => alert("Clicked!"),
@@ -58,6 +60,23 @@ export default class DialogPlayground extends React.Component {
               />
             </label>
           </div>
+
+          <div className="lab-playground__item">
+            <label htmlFor="selectedContent">
+              <strong>content:</strong><br />
+              <textarea
+                id="selectedContent"
+                onChange={this.handleTextPropChange}
+                placeholder="Insert content"
+                style={{
+                  width: "121%",
+                  minHeight: "100px",
+                  resize: "none",
+                }}
+              />
+            </label>
+          </div>
+
         </div>
       </div>
     );

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { isEmpty } from "lodash";
 
 import TextInput from "../labsystem/src/Input/TextInput";
 import Checkbox from "../labsystem/src/Checkbox";
@@ -72,7 +73,6 @@ export default class DialogPlayground extends React.Component {
       selectedTitle,
       selectedContent,
       selectedButtonText,
-      hasOutlineButton,
       selectedOutlineButtonText,
       selectedButtonResponseText,
       selectedOutlineButtonResponseText,
@@ -100,7 +100,7 @@ export default class DialogPlayground extends React.Component {
             onClick: () => alert(selectedButtonResponseText),
           }}
           outlineButtonProps={
-            hasOutlineButton
+            !isEmpty(selectedOutlineButtonText)
               ? {
                   text: selectedOutlineButtonText,
                   onClick: () => alert(selectedOutlineButtonResponseText),
@@ -116,7 +116,6 @@ export default class DialogPlayground extends React.Component {
     const {
       availableComponents,
       currentComponent,
-      hasOutlineButton,
       selectedIcon,
       selectedTitle,
       selectedContent,
@@ -180,9 +179,18 @@ export default class DialogPlayground extends React.Component {
             <TextInput
               id="selectedButtonText"
               onChange={this.handleTextPropChange}
-              placeholder="Insert button text"
               value={selectedButtonText}
-              label="button text:"
+              label="buttonProps.text"
+            />
+          </span>
+          <br />
+
+          <span className="lab-playground__item">
+            <TextInput
+              id="selectedOutlineButtonText"
+              onChange={this.handleTextPropChange}
+              value={selectedOutlineButtonText}
+              label="outlineButtonProps.text"
             />
           </span>
           <br />
@@ -192,38 +200,15 @@ export default class DialogPlayground extends React.Component {
               id="selectedIsModal"
               onChange={this.handleBoolPropChange}
               checked={selectedIsModal}
-              label="is modal"
+              label="isModal"
             />
           </span>
           <br />
-
-          <span className="lab-playground__item">
-            <Checkbox
-              id="hasOutlineButton"
-              onChange={this.handleBoolPropChange}
-              checked={hasOutlineButton}
-              label="has outline button"
-            />
-          </span>
-          <br />
-
-          {hasOutlineButton ? (
-            <span className="lab-playground__item">
-              <TextInput
-                id="selectedOutlineButtonText"
-                onChange={this.handleTextPropChange}
-                value={selectedOutlineButtonText}
-                label="outline button text:"
-              />
-              <br />
-            </span>
-          ) : null}
 
           {currentComponent === "MessageDialog" ? (
             <span className="lab-playground__item">
               <label htmlFor="selectedIcon">
                 <strong>icon: </strong>
-                <br />
                 <select
                   id="selectedIcon"
                   value={selectedIcon}

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -13,6 +13,7 @@ export default class DialogPlayground extends React.Component {
       hasOutlineButton: false,
       selectedOutlineButtonText: "Click me too!",
       selectedIcon: "star",
+      selectedIsModal: false,
     };
 
     this.state = {
@@ -36,7 +37,7 @@ export default class DialogPlayground extends React.Component {
     });
   };
 
-  handleHasOutlineButtonPropChange = (e) => {
+  handleBoolPropChange = (e) => {
     const { id, checked } = e.target;
     this.setState({
       [id]: checked,
@@ -74,6 +75,7 @@ export default class DialogPlayground extends React.Component {
       selectedOutlineButtonResponseText,
       selectedIcon,
       modalIsOpen,
+      selectedIsModal,
     } = this.state;
     const Component = availableComponents[currentComponent];
 
@@ -97,6 +99,7 @@ export default class DialogPlayground extends React.Component {
             content={selectedContent}
             handleClose={this.handleModalClose}
             isOpen={modalIsOpen}
+            isModal={selectedIsModal}
             buttonProps={{
               text: selectedButtonText,
               onClick: () => alert(selectedButtonResponseText),
@@ -125,6 +128,7 @@ export default class DialogPlayground extends React.Component {
       selectedContent,
       selectedButtonText,
       selectedOutlineButtonText,
+      selectedIsModal,
     } = this.state;
 
     return (
@@ -198,12 +202,25 @@ export default class DialogPlayground extends React.Component {
           <br />
 
           <span className="lab-playground__item">
+            <label htmlFor="selectedIsModal">
+              <strong>selectedIsModal: </strong>
+              <input
+                id="selectedIsModal"
+                type="checkbox"
+                onChange={this.handleBoolPropChange}
+                checked={selectedIsModal}
+              />
+            </label>
+          </span>
+          <br />
+
+          <span className="lab-playground__item">
             <label htmlFor="hasOutlineButton">
               <strong>hasOutlineButton: </strong>
               <input
                 id="hasOutlineButton"
                 type="checkbox"
-                onChange={this.handleHasOutlineButtonPropChange}
+                onChange={this.handleBoolPropChange}
                 checked={hasOutlineButton}
               />
             </label>
@@ -213,7 +230,7 @@ export default class DialogPlayground extends React.Component {
           {hasOutlineButton ? (
             <span className="lab-playground__item">
               <label htmlFor="selectedOutlineButtonText">
-                <strong>outlineButtonText:</strong>
+                <strong>selectedOutlineButtonText:</strong>
                 <br />
                 <input
                   id="selectedOutlineButtonText"
@@ -222,6 +239,7 @@ export default class DialogPlayground extends React.Component {
                   value={selectedOutlineButtonText}
                 />
               </label>
+              <br />
             </span>
           ) : null}
 

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -12,6 +12,9 @@ export default class DialogPlayground extends React.Component {
       selectedContent: "edit me",
       selectedButtonText: "edit me",
       selectedButtonResponseText: "edit me",
+      hasOutlineButton: false,
+      selectedOutlineButtonText: "edit me",
+      selectedOutlineButtonResponseText: "edit me",
     };
 
     this.state = {
@@ -19,8 +22,20 @@ export default class DialogPlayground extends React.Component {
       selectedContent: this.initialState.selectedContent,
       selectedButtonText: this.initialState.selectedButtonText,
       selectedButtonResponseText: this.initialState.selectedButtonResponseText,
+      hasOutlineButton: this.initialState.hasOutlineButton,
+      selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
+      selectedOutlineButtonResponseText: this.initialState.selectedOutlineButtonResponseText,
     };
   }
+
+  handleHasOutlineButtonPropChange = (e) => {
+    const { id, checked } = e.target;
+    this.setState({
+      [id]: checked,
+      selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
+      selectedOutlineButtonResponseText: this.initialState.selectedOutlineButtonResponseText,
+    });
+  };
 
   handleTextPropChange = (e) => {
     const { id, value } = e.target;
@@ -33,6 +48,9 @@ export default class DialogPlayground extends React.Component {
       selectedContent,
       selectedButtonText,
       selectedButtonResponseText,
+      hasOutlineButton,
+      selectedOutlineButtonText,
+      selectedOutlineButtonResponseText,
     } = this.state;
 
     return (
@@ -45,12 +63,19 @@ export default class DialogPlayground extends React.Component {
             text: selectedButtonText,
             onClick: () => alert(selectedButtonResponseText),
           }}
+          outlineButtonProps={ hasOutlineButton ?
+          {
+            text: selectedOutlineButtonText,
+            onClick: () => alert(selectedOutlineButtonResponseText),
+          } : undefined }
         />
       </>
     );
   };
 
   render() {
+    const { hasOutlineButton } = this.state;
+
     return (
       <div className="columns lab-playground">
         <div className="column lab-playground__component">
@@ -113,6 +138,49 @@ export default class DialogPlayground extends React.Component {
               />
             </label>
           </span>
+          <br />
+
+          <span className="lab-playground__item">
+            <label htmlFor="">
+              <strong>hasOutlineButton: </strong>
+              <input
+                id="hasOutlineButton"
+                type="checkbox"
+                onChange={this.handleHasOutlineButtonPropChange}
+              />
+            </label>
+          </span>
+          <br />
+
+          { hasOutlineButton ?
+            <>
+            <span className="lab-playground__item">
+              <label htmlFor="selectedOutlineButtonText">
+                <strong>selectedOutlineButtonText:</strong>
+                <br />
+                <input
+                  id="selectedOutlineButtonText"
+                  onChange={this.handleTextPropChange}
+                  placeholder="Insert outline button text"
+                />
+              </label>
+            </span>
+            <br />
+
+            <span className="lab-playground__item">
+              <label htmlFor="selectedOutlineButtonResponseText">
+                <strong>selectedOutlineButtonResponseText:</strong>
+                <br />
+                <input
+                  id="selectedOutlineButtonResponseText"
+                  onChange={this.handleTextPropChange}
+                  placeholder="Insert outline button response text"
+                />
+              </label>
+            </span>
+            <br />
+            </>
+          : undefined }
 
         </div>
       </div>

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -40,7 +40,6 @@ export default class DialogPlayground extends React.Component {
     const { id, checked } = e.target;
     this.setState({
       [id]: checked,
-      selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
     });
   };
 
@@ -198,36 +197,35 @@ export default class DialogPlayground extends React.Component {
           </span>
           <br />
 
-          {currentComponent !== "MessageDialog" ? (
-            <div>
-              <span className="lab-playground__item">
-                <label htmlFor="hasOutlineButton">
-                  <strong>hasOutlineButton: </strong>
-                  <input
-                    id="hasOutlineButton"
-                    type="checkbox"
-                    onChange={this.handleHasOutlineButtonPropChange}
-                  />
-                </label>
-              </span>
-              <br />
+          <span className="lab-playground__item">
+            <label htmlFor="hasOutlineButton">
+              <strong>hasOutlineButton: </strong>
+              <input
+                id="hasOutlineButton"
+                type="checkbox"
+                onChange={this.handleHasOutlineButtonPropChange}
+                checked={hasOutlineButton}
+              />
+            </label>
+          </span>
+          <br />
 
-              {hasOutlineButton ? (
-                <span className="lab-playground__item">
-                  <label htmlFor="selectedOutlineButtonText">
-                    <strong>outlineButtonText:</strong>
-                    <br />
-                    <input
-                      id="selectedOutlineButtonText"
-                      onChange={this.handleTextPropChange}
-                      placeholder="Insert outline button text"
-                      value={selectedOutlineButtonText}
-                    />
-                  </label>
-                </span>
-              ) : null}
-            </div>
-          ) : (
+          {hasOutlineButton ? (
+            <span className="lab-playground__item">
+              <label htmlFor="selectedOutlineButtonText">
+                <strong>outlineButtonText:</strong>
+                <br />
+                <input
+                  id="selectedOutlineButtonText"
+                  onChange={this.handleTextPropChange}
+                  placeholder="Insert outline button text"
+                  value={selectedOutlineButtonText}
+                />
+              </label>
+            </span>
+          ) : null}
+
+          {currentComponent === "MessageDialog" ? (
             <span className="lab-playground__item">
               <label htmlFor="selectedIcon">
                 <strong>icon: </strong>
@@ -245,7 +243,7 @@ export default class DialogPlayground extends React.Component {
                 </select>
               </label>
             </span>
-          )}
+          ) : null}
         </div>
       </div>
     );

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -26,8 +26,6 @@ export default class DialogPlayground extends React.Component {
       selectedOutlineButtonResponseText: "OutlineButton has been clicked!",
       modalIsOpen: false,
     };
-
-    this.handleOutsideClick = this.handleOutsideClick.bind(this);
   }
 
   handleCurrentComponentChange = (e) => {
@@ -57,20 +55,11 @@ export default class DialogPlayground extends React.Component {
   };
 
   showModal = () => {
-    document.addEventListener("click", this.handleOutsideClick, false);
     this.setState({ modalIsOpen: true });
   };
 
   handleModalClose = () => {
-    document.removeEventListener("click", this.handleOutsideClick, false);
     this.setState({ modalIsOpen: false });
-  };
-
-  handleOutsideClick = (e) => {
-    if (this.node.contains(e.target)) {
-      return;
-    }
-    this.handleModalClose();
   };
 
   renderCurrentComponent = () => {
@@ -103,27 +92,25 @@ export default class DialogPlayground extends React.Component {
           <button type="button" onClick={this.showModal}>
             show Modal
           </button>
-          {modalIsOpen && (
-            <Component
-              icon={selectedIcon}
-              title={selectedTitle}
-              content={selectedContent}
-              handleClose={this.handleModalClose}
-              isOpen={modalIsOpen}
-              buttonProps={{
-                text: selectedButtonText,
-                onClick: () => alert(selectedButtonResponseText),
-              }}
-              outlineButtonProps={
-                hasOutlineButton
-                  ? {
-                      text: selectedOutlineButtonText,
-                      onClick: () => alert(selectedOutlineButtonResponseText),
-                    }
-                  : undefined
-              }
-            />
-          )}
+          <Component
+            icon={selectedIcon}
+            title={selectedTitle}
+            content={selectedContent}
+            handleClose={this.handleModalClose}
+            isOpen={modalIsOpen}
+            buttonProps={{
+              text: selectedButtonText,
+              onClick: () => alert(selectedButtonResponseText),
+            }}
+            outlineButtonProps={
+              hasOutlineButton
+                ? {
+                    text: selectedOutlineButtonText,
+                    onClick: () => alert(selectedOutlineButtonResponseText),
+                  }
+                : undefined
+            }
+          />
         </div>
       </>
     );

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -24,7 +24,10 @@ export default class DialogPlayground extends React.Component {
       ...this.initialState,
       selectedButtonResponseText: "Button has been clicked!",
       selectedOutlineButtonResponseText: "OutlineButton has been clicked!",
+      modalIsOpen: false,
     };
+
+    this.handleOutsideClick = this.handleOutsideClick.bind(this);
   }
 
   handleCurrentComponentChange = (e) => {
@@ -53,6 +56,23 @@ export default class DialogPlayground extends React.Component {
     this.setState({ [id]: value });
   };
 
+  showModal = () => {
+    document.addEventListener("click", this.handleOutsideClick, false);
+    this.setState({ modalIsOpen: true });
+  };
+
+  handleModalClose = () => {
+    document.removeEventListener("click", this.handleOutsideClick, false);
+    this.setState({ modalIsOpen: false });
+  };
+
+  handleOutsideClick = (e) => {
+    if (this.node.contains(e.target)) {
+      return;
+    }
+    this.handleModalClose();
+  };
+
   renderCurrentComponent = () => {
     const {
       availableComponents,
@@ -65,6 +85,7 @@ export default class DialogPlayground extends React.Component {
       selectedButtonResponseText,
       selectedOutlineButtonResponseText,
       selectedIcon,
+      modalIsOpen,
     } = this.state;
     const Component = availableComponents[currentComponent];
 
@@ -73,23 +94,37 @@ export default class DialogPlayground extends React.Component {
         <h4>
           <strong>{currentComponent}</strong>
         </h4>
-        <Component
-          icon={selectedIcon}
-          title={selectedTitle}
-          content={selectedContent}
-          buttonProps={{
-            text: selectedButtonText,
-            onClick: () => alert(selectedButtonResponseText),
+        <div
+          className="container"
+          ref={(node) => {
+            this.node = node;
           }}
-          outlineButtonProps={
-            hasOutlineButton
-              ? {
-                  text: selectedOutlineButtonText,
-                  onClick: () => alert(selectedOutlineButtonResponseText),
-                }
-              : undefined
-          }
-        />
+        >
+          <button type="button" onClick={this.showModal}>
+            show Modal
+          </button>
+          {modalIsOpen && (
+            <Component
+              icon={selectedIcon}
+              title={selectedTitle}
+              content={selectedContent}
+              handleClose={this.handleModalClose}
+              isOpen={modalIsOpen}
+              buttonProps={{
+                text: selectedButtonText,
+                onClick: () => alert(selectedButtonResponseText),
+              }}
+              outlineButtonProps={
+                hasOutlineButton
+                  ? {
+                      text: selectedOutlineButtonText,
+                      onClick: () => alert(selectedOutlineButtonResponseText),
+                    }
+                  : undefined
+              }
+            />
+          )}
+        </div>
       </>
     );
   };

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -22,14 +22,9 @@ export default class DialogPlayground extends React.Component {
         MessageDialog,
       },
       currentComponent: "StandardDialog",
-      selectedTitle: this.initialState.selectedTitle,
-      selectedContent: this.initialState.selectedContent,
-      selectedButtonText: this.initialState.selectedButtonText,
-      hasOutlineButton: this.initialState.hasOutlineButton,
-      selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
+      ...this.initialState,
       selectedButtonResponseText: "Button has been clicked!",
       selectedOutlineButtonResponseText: "OutlineButton has been clicked!",
-      selectedIcon: this.initialState.selectedIcon,
     };
   }
 
@@ -37,13 +32,8 @@ export default class DialogPlayground extends React.Component {
     const { value } = e.target;
     this.setState({
       currentComponent: value,
-      selectedTitle: this.initialState.selectedTitle,
-      selectedContent: this.initialState.selectedContent,
-      selectedButtonText: this.initialState.selectedButtonText,
-      hasOutlineButton: this.initialState.hasOutlineButton,
-      selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
-      selectedIcon: this.initialState.selectedIcon,
-    });
+      ...this.initialState,
+    })
   };
 
   handleHasOutlineButtonPropChange = (e) => {

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -10,11 +10,15 @@ export default class DialogPlayground extends React.Component {
     this.initialState = {
       selectedTitle: "edit me",
       selectedContent: "edit me",
+      selectedButtonText: "edit me",
+      selectedButtonResponseText: "edit me",
     };
 
     this.state = {
       selectedTitle: this.initialState.selectedTitle,
       selectedContent: this.initialState.selectedContent,
+      selectedButtonText: this.initialState.selectedButtonText,
+      selectedButtonResponseText: this.initialState.selectedButtonResponseText,
     };
   }
 
@@ -24,7 +28,12 @@ export default class DialogPlayground extends React.Component {
   };
 
   renderCurrentComponent = () => {
-    const { selectedTitle, selectedContent } = this.state;
+    const {
+      selectedTitle,
+      selectedContent,
+      selectedButtonText,
+      selectedButtonResponseText,
+    } = this.state;
 
     return (
       <>
@@ -33,8 +42,8 @@ export default class DialogPlayground extends React.Component {
           title={selectedTitle}
           content={selectedContent}
           buttonProps={{
-            text: "click me!",
-            onClick: () => alert("Clicked!"),
+            text: selectedButtonText,
+            onClick: () => alert(selectedButtonResponseText),
           }}
         />
       </>
@@ -50,18 +59,20 @@ export default class DialogPlayground extends React.Component {
 
         <div className="column lab-playground__configs">
           <h4>Configurations</h4>
-          <div className="lab-playground__item">
+          <span className="lab-playground__item">
             <label htmlFor="selectedTitle">
-              <strong>title: </strong>
+              <strong>title:</strong>
+              <br />
               <input
                 id="selectedTitle"
                 onChange={this.handleTextPropChange}
                 placeholder="Insert title"
               />
             </label>
-          </div>
+          </span>
+          <br />
 
-          <div className="lab-playground__item">
+          <span className="lab-playground__item">
             <label htmlFor="selectedContent">
               <strong>content:</strong><br />
               <textarea
@@ -69,13 +80,39 @@ export default class DialogPlayground extends React.Component {
                 onChange={this.handleTextPropChange}
                 placeholder="Insert content"
                 style={{
-                  width: "121%",
+                  width: "100%",
                   minHeight: "100px",
                   resize: "none",
                 }}
               />
             </label>
-          </div>
+          </span>
+          <br />
+
+          <span className="lab-playground__item">
+            <label htmlFor="selectedButtonText">
+              <strong>buttonText:</strong>
+              <br />
+              <input
+                id="selectedButtonText"
+                onChange={this.handleTextPropChange}
+                placeholder="Insert button text"
+              />
+            </label>
+          </span>
+          <br />
+
+          <span className="lab-playground__item">
+            <label htmlFor="selectedButtonResponseText">
+              <strong>buttonResponseText:</strong>
+              <br />
+              <input
+                id="selectedButtonResponseText"
+                onChange={this.handleTextPropChange}
+                placeholder="Insert button response text"
+              />
+            </label>
+          </span>
 
         </div>
       </div>

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { isEmpty } from "lodash";
 
 import { StandardDialog, MessageDialog } from "../labsystem/src/Dialog";
 import { iconOptions } from "./assets";
@@ -8,11 +7,11 @@ export default class DialogPlayground extends React.Component {
   constructor(props) {
     super(props);
     this.initialState = {
-      selectedTitle: "edit me",
-      selectedContent: "edit me",
-      selectedButtonText: "edit me",
+      selectedTitle: "A generic Title",
+      selectedContent: "Some relevant content",
+      selectedButtonText: "Click me!",
       hasOutlineButton: false,
-      selectedOutlineButtonText: "edit me",
+      selectedOutlineButtonText: "Click me too!",
       selectedIcon: "star",
     };
 
@@ -33,7 +32,7 @@ export default class DialogPlayground extends React.Component {
     this.setState({
       currentComponent: value,
       ...this.initialState,
-    })
+    });
   };
 
   handleHasOutlineButtonPropChange = (e) => {
@@ -46,7 +45,7 @@ export default class DialogPlayground extends React.Component {
 
   handleTextPropChange = (e) => {
     const { id, value } = e.target;
-    this.setState({ [id]: !isEmpty(value) ? value : "edit me" });
+    this.setState({ [id]: value });
   };
 
   handleIconPropChange = (e) => {
@@ -101,6 +100,10 @@ export default class DialogPlayground extends React.Component {
       currentComponent,
       hasOutlineButton,
       selectedIcon,
+      selectedTitle,
+      selectedContent,
+      selectedButtonText,
+      selectedOutlineButtonText,
     } = this.state;
 
     return (
@@ -134,6 +137,7 @@ export default class DialogPlayground extends React.Component {
                 id="selectedTitle"
                 onChange={this.handleTextPropChange}
                 placeholder="Insert title"
+                value={selectedTitle}
               />
             </label>
           </span>
@@ -147,6 +151,7 @@ export default class DialogPlayground extends React.Component {
                 id="selectedContent"
                 onChange={this.handleTextPropChange}
                 placeholder="Insert content"
+                value={selectedContent}
                 style={{
                   width: "100%",
                   minHeight: "100px",
@@ -165,6 +170,7 @@ export default class DialogPlayground extends React.Component {
                 id="selectedButtonText"
                 onChange={this.handleTextPropChange}
                 placeholder="Insert button text"
+                value={selectedButtonText}
               />
             </label>
           </span>
@@ -193,6 +199,7 @@ export default class DialogPlayground extends React.Component {
                       id="selectedOutlineButtonText"
                       onChange={this.handleTextPropChange}
                       placeholder="Insert outline button text"
+                      value={selectedOutlineButtonText}
                     />
                   </label>
                 </span>

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -1,10 +1,10 @@
 import React from "react";
 import { isEmpty } from "lodash";
 
-import { StandardDialog } from "../labsystem/src/Dialog";
+import { StandardDialog, MessageDialog } from "../labsystem/src/Dialog";
+import { iconOptions } from "./assets";
 
 export default class DialogPlayground extends React.Component {
-
   constructor(props) {
     super(props);
     this.initialState = {
@@ -13,9 +13,15 @@ export default class DialogPlayground extends React.Component {
       selectedButtonText: "edit me",
       hasOutlineButton: false,
       selectedOutlineButtonText: "edit me",
+      selectedIcon: "star",
     };
 
     this.state = {
+      availableComponents: {
+        StandardDialog,
+        MessageDialog,
+      },
+      currentComponent: "StandardDialog",
       selectedTitle: this.initialState.selectedTitle,
       selectedContent: this.initialState.selectedContent,
       selectedButtonText: this.initialState.selectedButtonText,
@@ -23,8 +29,22 @@ export default class DialogPlayground extends React.Component {
       selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
       selectedButtonResponseText: "Button has been clicked!",
       selectedOutlineButtonResponseText: "OutlineButton has been clicked!",
+      selectedIcon: this.initialState.selectedIcon,
     };
   }
+
+  handleCurrentComponentChange = (e) => {
+    const { value } = e.target;
+    this.setState({
+      currentComponent: value,
+      selectedTitle: this.initialState.selectedTitle,
+      selectedContent: this.initialState.selectedContent,
+      selectedButtonText: this.initialState.selectedButtonText,
+      hasOutlineButton: this.initialState.hasOutlineButton,
+      selectedOutlineButtonText: this.initialState.selectedOutlineButtonText,
+      selectedIcon: this.initialState.selectedIcon,
+    });
+  };
 
   handleHasOutlineButtonPropChange = (e) => {
     const { id, checked } = e.target;
@@ -39,8 +59,15 @@ export default class DialogPlayground extends React.Component {
     this.setState({ [id]: !isEmpty(value) ? value : "edit me" });
   };
 
+  handleIconPropChange = (e) => {
+    const { id, value } = e.target;
+    this.setState({ [id]: value });
+  };
+
   renderCurrentComponent = () => {
     const {
+      availableComponents,
+      currentComponent,
       selectedTitle,
       selectedContent,
       selectedButtonText,
@@ -48,30 +75,43 @@ export default class DialogPlayground extends React.Component {
       selectedOutlineButtonText,
       selectedButtonResponseText,
       selectedOutlineButtonResponseText,
+      selectedIcon,
     } = this.state;
+    const Component = availableComponents[currentComponent];
 
     return (
       <>
-        <h4><strong>Standard Dialog</strong></h4>
-        <StandardDialog
+        <h4>
+          <strong>{currentComponent}</strong>
+        </h4>
+        <Component
+          icon={selectedIcon}
           title={selectedTitle}
           content={selectedContent}
           buttonProps={{
             text: selectedButtonText,
             onClick: () => alert(selectedButtonResponseText),
           }}
-          outlineButtonProps={ hasOutlineButton ?
-          {
-            text: selectedOutlineButtonText,
-            onClick: () => alert(selectedOutlineButtonResponseText),
-          } : undefined }
+          outlineButtonProps={
+            hasOutlineButton
+              ? {
+                  text: selectedOutlineButtonText,
+                  onClick: () => alert(selectedOutlineButtonResponseText),
+                }
+              : undefined
+          }
         />
       </>
     );
   };
 
   render() {
-    const { hasOutlineButton } = this.state;
+    const {
+      availableComponents,
+      currentComponent,
+      hasOutlineButton,
+      selectedIcon,
+    } = this.state;
 
     return (
       <div className="columns lab-playground">
@@ -81,6 +121,21 @@ export default class DialogPlayground extends React.Component {
 
         <div className="column lab-playground__configs">
           <h4>Configurations</h4>
+
+          <span className="lab-playground__item">
+            <label htmlFor="currentComponent">
+              <strong>variation: </strong>
+              <select onChange={this.handleCurrentComponentChange}>
+                {Object.keys(availableComponents).map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </span>
+          <br />
+
           <span className="lab-playground__item">
             <label htmlFor="selectedTitle">
               <strong>title:</strong>
@@ -96,7 +151,8 @@ export default class DialogPlayground extends React.Component {
 
           <span className="lab-playground__item">
             <label htmlFor="selectedContent">
-              <strong>content:</strong><br />
+              <strong>content:</strong>
+              <br />
               <textarea
                 id="selectedContent"
                 onChange={this.handleTextPropChange}
@@ -124,31 +180,53 @@ export default class DialogPlayground extends React.Component {
           </span>
           <br />
 
-          <span className="lab-playground__item">
-            <label htmlFor="">
-              <strong>hasOutlineButton: </strong>
-              <input
-                id="hasOutlineButton"
-                type="checkbox"
-                onChange={this.handleHasOutlineButtonPropChange}
-              />
-            </label>
-          </span>
-          <br />
+          {currentComponent !== "MessageDialog" ? (
+            <div>
+              <span className="lab-playground__item">
+                <label htmlFor="hasOutlineButton">
+                  <strong>hasOutlineButton: </strong>
+                  <input
+                    id="hasOutlineButton"
+                    type="checkbox"
+                    onChange={this.handleHasOutlineButtonPropChange}
+                  />
+                </label>
+              </span>
+              <br />
 
-          { hasOutlineButton ?
+              {hasOutlineButton ? (
+                <span className="lab-playground__item">
+                  <label htmlFor="selectedOutlineButtonText">
+                    <strong>outlineButtonText:</strong>
+                    <br />
+                    <input
+                      id="selectedOutlineButtonText"
+                      onChange={this.handleTextPropChange}
+                      placeholder="Insert outline button text"
+                    />
+                  </label>
+                </span>
+              ) : null}
+            </div>
+          ) : (
             <span className="lab-playground__item">
-              <label htmlFor="selectedOutlineButtonText">
-                <strong>selectedOutlineButtonText:</strong>
+              <label htmlFor="selectedIcon">
+                <strong>icon: </strong>
                 <br />
-                <input
-                  id="selectedOutlineButtonText"
-                  onChange={this.handleTextPropChange}
-                  placeholder="Insert outline button text"
-                />
+                <select
+                  id="selectedIcon"
+                  value={selectedIcon}
+                  onChange={this.handleIconPropChange}
+                >
+                  {iconOptions.slice(1).map((item) => (
+                    <option value={item} key={`icon-${item}`}>
+                      {item}
+                    </option>
+                  ))}
+                </select>
               </label>
             </span>
-          : undefined }
+          )}
         </div>
       </div>
     );

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -1,7 +1,65 @@
 import React from "react";
+import { isEmpty } from "lodash";
+
+import { StandardDialog } from "../labsystem/src/Dialog";
 
 export default class DialogPlayground extends React.Component {
- render() {
-  return (<h1>Dialog Playground</h1>);
- }
+
+  constructor(props) {
+    super(props);
+    this.initialState = {
+      selectedTitle: "edit me",
+    };
+
+    this.state = {
+      selectedTitle: this.initialState.selectedTitle,
+    };
+  }
+
+  handleTextPropChange = (e) => {
+    const { id, value } = e.target;
+    this.setState({ [id]: !isEmpty(value) ? value : "edit me" });
+  };
+
+  renderCurrentComponent = () => {
+    const { selectedTitle } = this.state;
+
+    return (
+      <>
+        <h4><strong>Standard Dialog</strong></h4>
+        <StandardDialog
+          title={selectedTitle}
+          content="This is a generic content."
+          buttonProps={{
+            text: "click me!",
+            onClick: () => alert("Clicked!"),
+          }}
+        />
+      </>
+    );
+  };
+
+  render() {
+    return (
+      <div className="columns lab-playground">
+        <div className="column lab-playground__component">
+          {this.renderCurrentComponent()}
+        </div>
+
+        <div className="column lab-playground__configs">
+          <h4>Configurations</h4>
+          <div className="lab-playground__item">
+            <label htmlFor="selectedTitle">
+              <strong>title: </strong>
+              <input
+                id="selectedTitle"
+                onChange={this.handleTextPropChange}
+                placeholder="Insert title"
+              />
+            </label>
+          </div>
+        </div>
+      </div>
+    );
+  }
 }

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -77,7 +77,7 @@ export default class DialogPlayground extends React.Component {
   };
 
   handleResize = () => {
-    this.setState({ windowIsSmall: window.outerWidth < 600 });
+    this.setState({ windowIsSmall: window.outerWidth <= 768 });
   };
 
   renderCurrentComponent = () => {
@@ -137,6 +137,7 @@ export default class DialogPlayground extends React.Component {
       selectedOutlineButtonText,
       selectedIsModal,
       windowIsSmall,
+      modalIsOpen,
     } = this.state;
 
     return (
@@ -219,6 +220,7 @@ export default class DialogPlayground extends React.Component {
                   onChange={this.handleBoolPropChange}
                   checked={selectedIsModal}
                   label="isModal"
+                  disabled={modalIsOpen}
                 />
               </span>
               <br />

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+export default class DialogPlayground extends React.Component {
+ render() {
+  return (<h1>Dialog Playground</h1>);
+ }
+}

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -52,7 +52,10 @@ import DialogPlayground from "../playgrounds/DialogPlayground";
   <Preview>
     <Story name="Message Dialog">
       <Fragment>
-        <MessageDialog />
+        <MessageDialog
+          title="Message Dialog"
+          content="A lot of elephants!"
+        />
       </Fragment>
     </Story>
   </Preview>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -55,6 +55,10 @@ import DialogPlayground from "../playgrounds/DialogPlayground";
         <MessageDialog
           title="Message Dialog"
           content="A lot of elephants!"
+          buttonProps={{
+            text: "click me!",
+            onClick: () => alert("Button has been clicked!"),
+          }}
         />
       </Fragment>
     </Story>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -18,7 +18,7 @@ import { StandardDialog } from "../labsystem/src/Dialog";
     <Story name="Standard Dialog">
       <Fragment>
         <StandardDialog
-          title="Standard Dialog Title"
+          title="Standard Dialog"
           content="One elephant. Two elephants. Three elephants."
           buttonProps={{
             text: "click me!",
@@ -28,6 +28,27 @@ import { StandardDialog } from "../labsystem/src/Dialog";
       </Fragment>
     </Story>
   </Preview>
+
+  <Preview>
+    <Story name="Standard Dialog with outline button">
+      <Fragment>
+        <StandardDialog
+          title="Standard Dialog with outline button"
+          content="One elephant. Two elephants. Three elephants."
+          buttonProps={{
+            text: "click me!",
+            onClick: () => alert("Button has been clicked!"),
+          }}
+          outlineButtonProps={{
+            text: "click me too!",
+            onClick: () => alert("OutlineButton has been clicked!"),
+          }}
+        />
+      </Fragment>
+    </Story>
+  </Preview>
+
+
 
   <Props of={StandardDialog} />
 </nav>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -17,57 +17,6 @@ import { iconOptions } from "../playgrounds/assets";
 <nav className="docs-content">
   <p>This is the start of Dialog's documentation.</p>
 
-  <Preview>
-    <Story name="Standard Dialog">
-      <Fragment>
-        <StandardDialog
-          title="Standard Dialog"
-          content="One elephant. Two elephants. Three elephants."
-          buttonProps={{
-            text: "click me!",
-            onClick: () => alert("Button has been clicked!"),
-          }}
-        />
-      </Fragment>
-    </Story>
-  </Preview>
-
-  <Preview>
-    <Story name="Standard Dialog with outline button">
-      <Fragment>
-        <StandardDialog
-          title="Standard Dialog with outline button"
-          content="One elephant. Two elephants. Three elephants."
-          buttonProps={{
-            text: "click me!",
-            onClick: () => alert("Button has been clicked!"),
-          }}
-          outlineButtonProps={{
-            text: "click me too!",
-            onClick: () => alert("OutlineButton has been clicked!"),
-          }}
-        />
-      </Fragment>
-    </Story>
-  </Preview>
-
-  <Preview>
-    <Story name="Message Dialog">
-      <Fragment>
-        <MessageDialog
-          icon={iconOptions[6]}
-          title="Message Dialog"
-          content="A lot of elephants!"
-          buttonProps={{
-            text: "click me!",
-            onClick: () => alert("Button has been clicked!"),
-          }}
-        />
-      </Fragment>
-    </Story>
-  </Preview>
-
-
   ### Playground
 
   <Preview>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
-import Dialog from "../labsystem/src/Dialog";
+import { StandardDialog } from "../labsystem/src/Dialog";
 
 <Meta title="Components/Dialog" />
 
@@ -14,5 +14,13 @@ import Dialog from "../labsystem/src/Dialog";
 <nav className="docs-content">
   <p>This is the start of Dialog's documentation.</p>
 
-  <Props of={Dialog} />
+  <Preview>
+    <Story name="Standard Dialog">
+      <Fragment>
+        <StandardDialog />
+      </Fragment>
+    </Story>
+  </Preview>
+
+  <Props of={StandardDialog} />
 </nav>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -21,7 +21,7 @@ import { StandardDialog } from "../labsystem/src/Dialog";
           title="Standard Dialog Title"
           content="One elephant. Two elephants. Three elephants."
           buttonProps={{
-            text: "click it!",
+            text: "click me!",
             onClick: () => alert("Button has been clicked!"),
           }}
         />

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -2,6 +2,7 @@ import { Fragment } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
 import { StandardDialog } from "../labsystem/src/Dialog";
+import DialogPlayground from "../playgrounds/DialogPlayground";
 
 <Meta title="Components/Dialog" />
 
@@ -49,6 +50,15 @@ import { StandardDialog } from "../labsystem/src/Dialog";
   </Preview>
 
 
+  ### Playground
+
+  <Preview>
+    <Story name="InteractiveDialogDemo">
+      <Fragment>
+        <DialogPlayground />
+      </Fragment>
+    </Story>
+  </Preview>
 
   <Props of={StandardDialog} />
 </nav>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+import { Meta, Story, Canvas, ArgsTable } from "@storybook/addon-docs/blocks";
 
 import { StandardDialog, MessageDialog } from "../labsystem/src/Dialog";
 import DialogPlayground from "../playgrounds/DialogPlayground";
@@ -19,13 +19,13 @@ import { iconOptions } from "../playgrounds/assets";
 
   ### Playground
 
-  <Preview>
+  <Canvas>
     <Story name="InteractiveDialogDemo">
       <Fragment>
         <DialogPlayground />
       </Fragment>
     </Story>
-  </Preview>
+  </Canvas>
 
-  <Props of={StandardDialog} />
+  <ArgsTable of={StandardDialog} />
 </nav>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -1,0 +1,18 @@
+import { Fragment } from "react";
+import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
+
+import Dialog from "../labsystem/src/Dialog";
+
+<Meta title="Components/Dialog" />
+
+<header className="docs-title">
+  <div>
+    <h1 className="docs-title__text">Dialog</h1>
+  </div>
+</header>
+
+<nav className="docs-content">
+  <p>This is the start of Dialog's documentation.</p>
+
+  <Props of={Dialog} />
+</nav>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -1,7 +1,7 @@
 import { Fragment } from "react";
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 
-import { StandardDialog } from "../labsystem/src/Dialog";
+import { StandardDialog, MessageDialog } from "../labsystem/src/Dialog";
 import DialogPlayground from "../playgrounds/DialogPlayground";
 
 <Meta title="Components/Dialog" />
@@ -45,6 +45,14 @@ import DialogPlayground from "../playgrounds/DialogPlayground";
             onClick: () => alert("OutlineButton has been clicked!"),
           }}
         />
+      </Fragment>
+    </Story>
+  </Preview>
+
+  <Preview>
+    <Story name="Message Dialog">
+      <Fragment>
+        <MessageDialog />
       </Fragment>
     </Story>
   </Preview>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -17,7 +17,14 @@ import { StandardDialog } from "../labsystem/src/Dialog";
   <Preview>
     <Story name="Standard Dialog">
       <Fragment>
-        <StandardDialog />
+        <StandardDialog
+          title="Standard Dialog Title"
+          content="One elephant. Two elephants. Three elephants."
+          buttonProps={{
+            text: "click it!",
+            onClick: () => alert("Button has been clicked!"),
+          }}
+        />
       </Fragment>
     </Story>
   </Preview>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -4,6 +4,8 @@ import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { StandardDialog, MessageDialog } from "../labsystem/src/Dialog";
 import DialogPlayground from "../playgrounds/DialogPlayground";
 
+import { iconOptions } from "../playgrounds/assets";
+
 <Meta title="Components/Dialog" />
 
 <header className="docs-title">
@@ -53,6 +55,7 @@ import DialogPlayground from "../playgrounds/DialogPlayground";
     <Story name="Message Dialog">
       <Fragment>
         <MessageDialog
+          icon={iconOptions[6]}
           title="Message Dialog"
           content="A lot of elephants!"
           buttonProps={{


### PR DESCRIPTION
**Link to task:**
https://labcodes.atlassian.net/browse/DSYS-23

**Description:**
This PR implements the JS behavior of `StandardDialog` and `MessageDialog`. It introduces a `DialogPlayground.js` for the documentation on `Dialog.stories.mdx`. It also introduces the backbone for styling in `_lab-dialog.scss`. 

A new dependency `react-focus-trap` is added to the project for trapping the focus inside modal _Dialogs_. Therefore, make sure to run `npm install` inside the directory `labstorybook/labsystem/`.

**How to test:**
- Check if the `Dialog` tab appears at the left sidebar.
- Check if `Playground` session is visible and works well with varied input. Edit `Configurations` at the right side, then press `Show Modal` button.
--
- With `isModal` **checked**, press `Show Modal`, then try to move focus around with TAB. Check if focus is **trapped** and scroll down is **locked**;
- With `isModal` **unchecked**, press `Show Modal`, then try to move focus around with TAB. Check if focus is **not trapped** and scroll down is **unlocked**;
- With `isModal` **unchecked**, press `Show Modal`, then reduce the window size until reaching mobile width. Check if overlay **appears**, focus is **trapped**, and scroll down is **locked**. Now increase the window size until crossing that threshold. Check if overlay **disappears**, focus is **released** and scroll down is **unlocked**.
- When _overlay_ is **on**, check if _Dialog_ **closes** when clicking outside of _Dialog_;
- When _overlay_ is **off**, check if _Dialog_ **does not close** when clicking outside of _Dialog_;
- When _Dialog_ is **open**, close by clicking on `Close button` (X);
- When _Dialog_ is **open**, close by clicking on `Swipe down button` (v);
--
- With mobile emulator **enabled** on dev tools, click and hold on `Swipe down button`, swipe at least 75px to the bottom, then release. Check if _Dialog_ **closes**.