### PR TITLE
fix-radio: Remove defaultChecked and local state on the Radio component

### DIFF
--- a/labsystem/src/Radio.js
+++ b/labsystem/src/Radio.js
@@ -13,7 +13,6 @@ export default class Radio extends React.Component {
     value: PropTypes.oneOfType([string, number, bool]).isRequired,
     disabled: PropTypes.bool,
     checked: PropTypes.bool,
-    defaultChecked: PropTypes.bool,
     className: PropTypes.string,
     onChange: PropTypes.func,
   };
@@ -21,48 +20,15 @@ export default class Radio extends React.Component {
   static defaultProps = {
     disabled: false,
     checked: undefined,
-    defaultChecked: undefined,
     className: undefined,
     onChange: undefined,
   };
-
-  constructor(props) {
-    super(props);
-    const { defaultChecked, checked, id } = props;
-    if (!isUndefined(defaultChecked) && !isUndefined(checked)) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `You are setting both checked and defaultChecked for radio input ${id} at the same time. We always initialize the radio with defaultChecked. Make sure this is the behaviour you want.`
-      );
-    }
-
-    let localChecked = false;
-    if (defaultChecked) {
-      localChecked = defaultChecked;
-    } else if (!isUndefined(checked)) {
-      localChecked = checked;
-    }
-
-    this.state = {
-      localChecked,
-    };
-  }
-
-  componentDidUpdate(prevProps) {
-    const { checked } = this.props;
-    if (checked !== prevProps.checked) {
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState(() => ({ localChecked: checked }));
-    }
-  }
 
   handleOnChange = (event) => {
     const { onChange } = this.props;
     if (!isUndefined(onChange)) {
       onChange(event);
     }
-
-    this.setState((state) => ({ localChecked: !state.localChecked }));
   };
 
   render() {
@@ -74,11 +40,11 @@ export default class Radio extends React.Component {
           className={`lab-radio ${className || ""}`}
           type="radio"
           id={id}
-          {...(disabled ? { disabled } : undefined)}
           checked={checked}
           name={name}
           value={value}
           onChange={this.handleOnChange}
+          {...(disabled ? { disabled } : undefined)}
         />
         <label className="lab-radio__label" htmlFor={id}>
           <span className="lab-radio__container" />

--- a/labsystem/src/Radio.test.js
+++ b/labsystem/src/Radio.test.js
@@ -25,26 +25,6 @@ describe("Radio", () => {
     expect(renderedComponent).toMatchSnapshot();
   });
 
-  it("raises console.warn when passing checked and defaultChecked at the same time", async () => {
-    console.warn = jest.fn();
-
-    shallow(
-      <Radio
-        name="test-radio-group"
-        id="test-radio"
-        label="test radio"
-        value="radio1"
-        checked
-        defaultChecked
-      />
-    );
-
-    const consoleText =
-      "You are setting both checked and defaultChecked for radio input test-radio at the same time. We always initialize the radio with defaultChecked. Make sure this is the behaviour you want.";
-
-    expect(console.warn).toBeCalledWith(consoleText);
-  });
-
   it("renders as expected when passing disabled as true", async () => {
     const renderedComponent = renderer
       .create(
@@ -77,55 +57,6 @@ describe("Radio", () => {
     expect(renderedComponent).toMatchSnapshot();
   });
 
-  it("inits state.localChecked with defaultChecked if defined", async () => {
-    let component = shallow(
-      <Radio
-        name="test-radio"
-        id="test-radio"
-        label="test radio"
-        value="radio1"
-        defaultChecked
-      />
-    );
-    expect(component.state().localChecked).toBe(true);
-
-    component = shallow(
-      <Radio
-        name="test-radio"
-        id="test-radio"
-        label="test radio"
-        value="radio1"
-        defaultChecked={false}
-      />
-    );
-    expect(component.state().localChecked).toBe(false);
-
-    component = shallow(
-      <Radio
-        name="test-radio"
-        id="test-radio"
-        label="test radio"
-        value="radio1"
-      />
-    );
-    expect(component.state().localChecked).toBe(false);
-  });
-
-  it("changes state when input changes", async () => {
-    const component = shallow(
-      <Radio
-        name="test-radio"
-        id="test-radio"
-        label="test radio"
-        value="radio1"
-      />
-    );
-
-    expect(component.state().localChecked).toBe(false);
-    component.find("input").at(0).simulate("change");
-    expect(component.state().localChecked).toBe(true);
-  });
-
   it("calls props.onChange passing event when input changes", async () => {
     const mockOnChange = jest.fn();
     const component = shallow(
@@ -138,12 +69,8 @@ describe("Radio", () => {
       />
     );
 
-    expect(component.state().localChecked).toBe(false);
     expect(mockOnChange).not.toBeCalled();
-
     component.find("input").at(0).simulate("change", { test: "event" });
-
-    expect(component.state().localChecked).toBe(true);
     expect(mockOnChange).toBeCalledWith({ test: "event" });
   });
 });


### PR DESCRIPTION
**Link to task:** https://labcodes.atlassian.net/browse/DSYS-177
**Staging app:** https://fix-radio--labstorybook-master.netlify.app/

After reviewing how radio buttons and radio groups are implemented, I concluded that we implemented everything right, but that the `defaultChecked` and the `checked` props had the same effect.
For that reason, I both removed the `defaultChecked` prop and the `localState`, since the `localState` only existed to sync the `defaultChecked` and the `checked` props locally inside the component.