### PR TITLE
Fix checkbox

### DIFF
--- a/labsystem/src/Checkbox.js
+++ b/labsystem/src/Checkbox.js
@@ -50,29 +50,28 @@ export default class Checkbox extends React.Component {
     this.state = {
       localChecked,
     };
+
+    this.inputRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.checkIndeterminate();
   }
 
   componentDidUpdate(prevProps) {
     const { checked } = this.props;
+
     if (checked !== prevProps.checked) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState(() => ({ localChecked: checked }));
     }
+
+    this.checkIndeterminate();
   }
 
-  checkIcon = () => {
-    const { disabled, indeterminate } = this.props;
-    let color = "white";
-    let type = "check";
-
-    if (indeterminate) {
-      type = "minus";
-    }
-    if (disabled) {
-      color = "mineral-40";
-    }
-
-    return <Icon type={type} color={color} size="small" />;
+  checkIndeterminate = () => {
+    const { indeterminate } = this.props;
+    this.inputRef.current.indeterminate = indeterminate;
   };
 
   handleOnChange = (event) => {
@@ -102,6 +101,7 @@ export default class Checkbox extends React.Component {
         <input
           className={`lab-checkbox ${className || ""}`}
           type="checkbox"
+          ref={this.inputRef}
           id={id}
           name={name}
           checked={localChecked}
@@ -111,7 +111,13 @@ export default class Checkbox extends React.Component {
         />
         <label className="lab-checkbox__label" htmlFor={id}>
           <span className="lab-checkbox__box">
-            {localChecked || indeterminate ? this.checkIcon() : ""}
+            {localChecked || indeterminate ? (
+              <Icon
+                type={indeterminate ? "minus" : "check"}
+                color={disabled ? "mineral-40" : "white"}
+                size="small"
+              />
+            ) : null}
           </span>
           {label}
         </label>

--- a/labsystem/src/Checkbox.test.js
+++ b/labsystem/src/Checkbox.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import renderer from "react-test-renderer";
 
 import Checkbox from "./Checkbox";
@@ -12,13 +12,24 @@ describe("Checkbox", () => {
   });
 
   it("renders with base props", async () => {
+    const mockedIndeterminate = jest.fn();
     const renderedComponent = renderer
       .create(
         <Checkbox
           name="test-checkbox-group"
           id="test-checkbox"
           label="test checkbox"
-        />
+        />,
+        {
+          createNodeMock: (element) => {
+            if (element.type === "input") {
+              return {
+                indeterminate: mockedIndeterminate,
+              };
+            }
+            return {};
+          },
+        }
       )
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
@@ -27,7 +38,7 @@ describe("Checkbox", () => {
   it("raises console.warn when passing checked and defaultChecked at the same time", async () => {
     console.warn = jest.fn();
 
-    shallow(
+    mount(
       <Checkbox
         name="test-checkbox-group"
         id="test-checkbox"
@@ -44,6 +55,7 @@ describe("Checkbox", () => {
   });
 
   it("renders as expected when passing disabled as true", async () => {
+    const mockedIndeterminate = jest.fn();
     const renderedComponent = renderer
       .create(
         <Checkbox
@@ -51,7 +63,17 @@ describe("Checkbox", () => {
           id="test-checkbox"
           label="test checkbox"
           disabled
-        />
+        />,
+        {
+          createNodeMock: (element) => {
+            if (element.type === "input") {
+              return {
+                indeterminate: mockedIndeterminate,
+              };
+            }
+            return {};
+          },
+        }
       )
       .toJSON();
 
@@ -59,6 +81,7 @@ describe("Checkbox", () => {
   });
 
   it("renders as expected when passing indeterminate as true", async () => {
+    const mockedIndeterminate = jest.fn();
     const renderedComponent = renderer
       .create(
         <Checkbox
@@ -67,13 +90,24 @@ describe("Checkbox", () => {
           label="test checkbox"
           indeterminate
           checked
-        />
+        />,
+        {
+          createNodeMock: (element) => {
+            if (element.type === "input") {
+              return {
+                indeterminate: mockedIndeterminate,
+              };
+            }
+            return {};
+          },
+        }
       )
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
   it("renders as expected when passing a different className", async () => {
+    const mockedIndeterminate = jest.fn();
     const renderedComponent = renderer
       .create(
         <Checkbox
@@ -82,14 +116,24 @@ describe("Checkbox", () => {
           label="test checkbox"
           className="lab-checkbox--purple"
           checked
-        />
+        />,
+        {
+          createNodeMock: (element) => {
+            if (element.type === "input") {
+              return {
+                indeterminate: mockedIndeterminate,
+              };
+            }
+            return {};
+          },
+        }
       )
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
   it("inits state.localChecked with defaultChecked if defined", async () => {
-    let component = shallow(
+    let component = mount(
       <Checkbox
         name="test-checkbox"
         id="test-checkbox"
@@ -99,7 +143,7 @@ describe("Checkbox", () => {
     );
     expect(component.state().localChecked).toBe(true);
 
-    component = shallow(
+    component = mount(
       <Checkbox
         name="test-checkbox"
         id="test-checkbox"
@@ -109,14 +153,32 @@ describe("Checkbox", () => {
     );
     expect(component.state().localChecked).toBe(false);
 
-    component = shallow(
+    component = mount(
       <Checkbox name="test-checkbox" id="test-checkbox" label="test checkbox" />
     );
     expect(component.state().localChecked).toBe(false);
   });
 
+  it("sets input as indeterminate", async () => {
+    const component = mount(
+      <Checkbox name="test-checkbox" id="test-checkbox" label="test checkbox" />
+    );
+
+    expect(component.find("input[indeterminate]").length).toBeFalsy();
+
+    component.setProps({ indeterminate: true });
+    component.update();
+
+    expect(component.find("input[indeterminate]")).toBeTruthy();
+
+    component.setProps({ indeterminate: undefined });
+    component.update();
+
+    expect(component.find("input[indeterminate]").length).toBeFalsy();
+  });
+
   it("changes state when input changes", async () => {
-    const component = shallow(
+    const component = mount(
       <Checkbox name="test-checkbox" id="test-checkbox" label="test checkbox" />
     );
 
@@ -127,7 +189,7 @@ describe("Checkbox", () => {
 
   it("calls props.onChange passing event when input changes", async () => {
     const mockOnChange = jest.fn();
-    const component = shallow(
+    const component = mount(
       <Checkbox
         name="test-checkbox"
         id="test-checkbox"
@@ -142,6 +204,6 @@ describe("Checkbox", () => {
     component.find("input").at(0).simulate("change", { test: "event" });
 
     expect(component.state().localChecked).toBe(true);
-    expect(mockOnChange).toBeCalledWith({ test: "event" });
+    expect(mockOnChange).toBeCalled();
   });
 });

--- a/labsystem/src/Checkbox.test.js
+++ b/labsystem/src/Checkbox.test.js
@@ -132,6 +132,32 @@ describe("Checkbox", () => {
     expect(renderedComponent).toMatchSnapshot();
   });
 
+  it("renders as expected when passing indeterminate", async () => {
+    const mockedIndeterminate = jest.fn();
+    const renderedComponent = renderer
+      .create(
+        <Checkbox
+          name="test-checkbox"
+          id="test-checkbox"
+          label="test checkbox"
+          className="lab-checkbox--purple"
+          indeterminate
+        />,
+        {
+          createNodeMock: (element) => {
+            if (element.type === "input") {
+              return {
+                indeterminate: mockedIndeterminate,
+              };
+            }
+            return {};
+          },
+        }
+      )
+      .toJSON();
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
   it("inits state.localChecked with defaultChecked if defined", async () => {
     let component = mount(
       <Checkbox

--- a/labsystem/src/__snapshots__/Checkbox.test.js.snap
+++ b/labsystem/src/__snapshots__/Checkbox.test.js.snap
@@ -49,6 +49,32 @@ Array [
 ]
 `;
 
+exports[`Checkbox renders as expected when passing indeterminate 1`] = `
+Array [
+  <input
+    checked={false}
+    className="lab-checkbox lab-checkbox--purple"
+    id="test-checkbox"
+    name="test-checkbox"
+    onChange={[Function]}
+    type="checkbox"
+  />,
+  <label
+    className="lab-checkbox__label"
+    htmlFor="test-checkbox"
+  >
+    <span
+      className="lab-checkbox__box"
+    >
+      <span
+        className="lab-icon lab-icon--minus lab-icon--white lab-icon--small"
+      />
+    </span>
+    test checkbox
+  </label>,
+]
+`;
+
 exports[`Checkbox renders as expected when passing indeterminate as true 1`] = `
 Array [
   <input

--- a/labsystem/src/__snapshots__/Checkbox.test.js.snap
+++ b/labsystem/src/__snapshots__/Checkbox.test.js.snap
@@ -43,9 +43,7 @@ Array [
   >
     <span
       className="lab-checkbox__box"
-    >
-      
-    </span>
+    />
     test checkbox
   </label>,
 ]
@@ -93,9 +91,7 @@ Array [
   >
     <span
       className="lab-checkbox__box"
-    >
-      
-    </span>
+    />
     test checkbox
   </label>,
 ]


### PR DESCRIPTION
**Link to task:** https://labcodes.atlassian.net/browse/DSYS-160
**Staging app:** https://fix-checkbox--labstorybook-master.netlify.app

This PR changes the behavior of a Checkbox with `indeterminate` as true.
Now, the input will always render as indeterminate whenever the prop is passed, regardless of the `checked` state.