### PR TITLE
Fix icon

### DIFF
--- a/.storybook/scss/doc-narrow-sidebar.scss
+++ b/.storybook/scss/doc-narrow-sidebar.scss
@@ -270,7 +270,7 @@ $vivid-sidebar-all-colors: (
   &:active {
     background-color: $white-75;
 
-    .lab-icon {
+    .lab-icon--menu-expand {
       background-color: map-get($narrow-sidebar-theme, "70");
     }
   }
@@ -326,7 +326,8 @@ $vivid-sidebar-all-colors: (
 
         &:hover {
           color: $white;
-          .lab-icon {
+
+          .lab-narrow-sidebar__item-icon {
             background-color: $white;
           }
         }

--- a/labsystem/scss/components/_lab-sidebar.scss
+++ b/labsystem/scss/components/_lab-sidebar.scss
@@ -390,7 +390,8 @@ $vivid-bg: map-get($narrow-sidebar-theme, "60");
 
     &:hover {
       color: $white;
-      .lab-icon {
+
+      .lab-narrow-sidebar__item-icon {
         background-color: $white;
       }
     }

--- a/labsystem/scss/components/_lab-tag.scss
+++ b/labsystem/scss/components/_lab-tag.scss
@@ -246,7 +246,10 @@ $tag-vivid-hover-color: mix($tag-vivid-color, black, 50%);
         color: $tag-text-color;
         box-shadow: 0 0 0 4px $tag-hover-shadow-color;
 
-        .lab-icon {
+        .lab-tag--left-icon,
+        .lab-tag--check-icon,
+        .lab-tag--dropdown-icon,
+        .lab-tag--remove-icon {
           background-color: $tag-vivid-color;
         }
       }


### PR DESCRIPTION
**Jira issue:** https://labcodes.atlassian.net/browse/DSYS-199

This PR replaces the use of the `lab-icon` class in component's styles to the element classes to avoid unwanted overwrites in the `lab-icon` component style. I've found:
- outlined vivid tag icons on hover
- narrow sidebar mobile expand button on active state
- vivid narrow sidebar item on hover (I've fixed but this code shouldn't be there since it's a documentation only style)