### PR TITLE
DSYS-204: fix-tag-focus

### DIFF
--- a/labsystem/src/Tags/AbstractTag.js
+++ b/labsystem/src/Tags/AbstractTag.js
@@ -67,7 +67,8 @@ export default class AbstractTag extends React.Component {
         }
         onClick={this.handleEvent}
         onKeyPress={this.handleEvent}
-        role="presentation"
+        role="button"
+        tabIndex="0"
       >
         {renderPrefix}
         {text}

--- a/labsystem/src/Tags/__snapshots__/AbstractTag.test.js.snap
+++ b/labsystem/src/Tags/__snapshots__/AbstractTag.test.js.snap
@@ -5,7 +5,8 @@ exports[`AbstractTag renders with base props for 'dropdown' type 1`] = `
   className="lab-tag lab-tag--dropdown lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test DropdownTag
 </span>
@@ -16,7 +17,8 @@ exports[`AbstractTag renders with base props for 'removable' type 1`] = `
   className="lab-tag lab-tag--removable lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test RemovableTag
 </span>
@@ -27,7 +29,8 @@ exports[`AbstractTag renders with base props for 'simple' type 1`] = `
   className="lab-tag  lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test SimpleTag
 </span>
@@ -38,7 +41,8 @@ exports[`AbstractTag renders with base props for 'togglable' type 1`] = `
   className="lab-tag lab-tag--togglable lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test TogglableTag
 </span>

--- a/labsystem/src/Tags/__snapshots__/DropdownTag.test.js.snap
+++ b/labsystem/src/Tags/__snapshots__/DropdownTag.test.js.snap
@@ -5,7 +5,8 @@ exports[`DropdownTag render as outline 1`] = `
   className="lab-tag lab-tag--dropdown lab-tag--outline lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render outline DropdownTag
   <span
@@ -23,7 +24,8 @@ exports[`DropdownTag renders as disabled 1`] = `
   className="lab-tag lab-tag--dropdown lab-tag--disabled lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render disabled DropdownTag
   <span
@@ -41,7 +43,8 @@ exports[`DropdownTag renders with a pink color 1`] = `
   className="lab-tag lab-tag--dropdown lab-tag--pink-pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render pink DropdownTag
   <span
@@ -59,7 +62,8 @@ exports[`DropdownTag renders with base props 1`] = `
   className="lab-tag lab-tag--dropdown lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render DropdownTag
   <span

--- a/labsystem/src/Tags/__snapshots__/RemovableTag.test.js.snap
+++ b/labsystem/src/Tags/__snapshots__/RemovableTag.test.js.snap
@@ -5,7 +5,8 @@ exports[`RemovableTag renders as disabled 1`] = `
   className="lab-tag lab-tag--removable lab-tag--disabled lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render disabled RemovableTag
   <span
@@ -23,7 +24,8 @@ exports[`RemovableTag renders as outline 1`] = `
   className="lab-tag lab-tag--removable lab-tag--outline lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render outline RemovableTag
   <span
@@ -41,7 +43,8 @@ exports[`RemovableTag renders with a green color 1`] = `
   className="lab-tag lab-tag--removable lab-tag--green-pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render green RemovableTag
   <span
@@ -59,7 +62,8 @@ exports[`RemovableTag renders with base props 1`] = `
   className="lab-tag lab-tag--removable lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render RemovableTag
   <span

--- a/labsystem/src/Tags/__snapshots__/SimpleTag.test.js.snap
+++ b/labsystem/src/Tags/__snapshots__/SimpleTag.test.js.snap
@@ -5,7 +5,8 @@ exports[`SimpleTag renders as expected with a magnifying-glass icon 1`] = `
   className="lab-tag  lab-tag--has-left-icon lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   <span
     className="lab-icon lab-icon--magnifying-glass lab-icon--black-75 lab-icon--petit lab-tag--left-icon"
@@ -19,7 +20,8 @@ exports[`SimpleTag renders as expected with a purple color 1`] = `
   className="lab-tag  lab-tag--purple-pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render purple SimpleTag
 </span>
@@ -30,7 +32,8 @@ exports[`SimpleTag renders as expected with a thumb 1`] = `
   className="lab-tag  lab-tag--has-thumb lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   <img
     alt=""
@@ -46,7 +49,8 @@ exports[`SimpleTag renders as expected with a vivid skin 1`] = `
   className="lab-tag  lab-tag--vivid"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render vivid SimpleTag
 </span>
@@ -57,7 +61,8 @@ exports[`SimpleTag renders as expected with outline as true 1`] = `
   className="lab-tag  lab-tag--outline lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render outline SimpleTag
 </span>
@@ -68,7 +73,8 @@ exports[`SimpleTag renders with base props 1`] = `
   className="lab-tag  lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   Test render SimpleTag
 </span>

--- a/labsystem/src/Tags/__snapshots__/TogglableTag.test.js.snap
+++ b/labsystem/src/Tags/__snapshots__/TogglableTag.test.js.snap
@@ -5,7 +5,8 @@ exports[`TogglableTag renders as expected with a yellow color 1`] = `
   className="lab-tag lab-tag--togglable lab-tag--yellow-pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   <span
     className="lab-icon lab-icon--check lab-icon--black-75 lab-icon--petit lab-tag--check-icon lab-tag--check-icon-off"
@@ -19,7 +20,8 @@ exports[`TogglableTag renders as expected with disabled as true 1`] = `
   className="lab-tag lab-tag--togglable lab-tag--disabled lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   <span
     className="lab-icon lab-icon--check lab-icon--black-75 lab-icon--petit lab-tag--check-icon lab-tag--check-icon-off"
@@ -33,7 +35,8 @@ exports[`TogglableTag renders as expected with outline as true 1`] = `
   className="lab-tag lab-tag--togglable lab-tag--outline lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   <span
     className="lab-icon lab-icon--check lab-icon--black-75 lab-icon--petit lab-tag--check-icon lab-tag--check-icon-off"
@@ -47,7 +50,8 @@ exports[`TogglableTag renders with a pale skin if not isOn 1`] = `
   className="lab-tag lab-tag--togglable lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   <span
     className="lab-icon lab-icon--check lab-icon--black-75 lab-icon--petit lab-tag--check-icon lab-tag--check-icon-off"
@@ -61,7 +65,8 @@ exports[`TogglableTag renders with a vivid skin and a checked icon if isOn 1`] =
   className="lab-tag lab-tag--togglable lab-tag--selected lab-tag--vivid"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   <span
     className="lab-icon lab-icon--check lab-icon--black-75 lab-icon--petit lab-tag--check-icon lab-tag--check-icon-on"
@@ -75,7 +80,8 @@ exports[`TogglableTag renders with base props 1`] = `
   className="lab-tag lab-tag--togglable lab-tag--pale"
   onClick={[Function]}
   onKeyPress={[Function]}
-  role="presentation"
+  role="button"
+  tabIndex="0"
 >
   <span
     className="lab-icon lab-icon--check lab-icon--black-75 lab-icon--petit lab-tag--check-icon lab-tag--check-icon-off"


### PR DESCRIPTION
**Link to task**
https://labcodes.atlassian.net/browse/DSYS-204

**Description**
`Tags` are implemented as `span`. Therefore, a `tabIndex` is required for enabling such a non-input element to be focusable. Spanshots are updated to reflect the proposed changes. 

**How to test**
With the DS running, go to the `Tags` section and try to focus all kind of tags with `TAB` key.