### PR TITLE
DSYS-157 & DSYS-161: Fix tests

### DIFF
--- a/labsystem/src/Button/AbstractButton.test.js
+++ b/labsystem/src/Button/AbstractButton.test.js
@@ -13,14 +13,14 @@ describe("AbstractButton", () => {
 
   it("renders with base props for outline variant", async () => {
     const renderedComponent = renderer
-      .create(<AbstractButton variant="outline" text="Test Default Button" />)
+      .create(<AbstractButton variant="outline" text="Test Outline Button" />)
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
   it("renders with base props for text variant", async () => {
     const renderedComponent = renderer
-      .create(<AbstractButton variant="text" text="Test Default Button" />)
+      .create(<AbstractButton variant="text" text="Test Text Button" />)
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });

--- a/labsystem/src/Button/Button.test.js
+++ b/labsystem/src/Button/Button.test.js
@@ -53,4 +53,11 @@ describe("Button", () => {
     shallowedButton.simulate("click");
     expect(mockOnClick.mock.calls.length).toEqual(1);
   });
+
+  it("renders as expected if full width", async () => {
+    const renderedComponent = renderer
+      .create(<Button text="Test Default fullWidth Button" fullWidth />)
+      .toJSON();
+    expect(renderedComponent).toMatchSnapshot();
+  });
 });

--- a/labsystem/src/Button/Button.test.js
+++ b/labsystem/src/Button/Button.test.js
@@ -60,4 +60,11 @@ describe("Button", () => {
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
+
+  it("renders with full width", async () => {
+    const mountedComponent = mount(
+      <Button text="Test fullWidth Button" fullWidth />
+    );
+    expect(mountedComponent.find(".lab-btn--block")).toHaveLength(1);
+  });
 });

--- a/labsystem/src/Button/OutlineButton.test.js
+++ b/labsystem/src/Button/OutlineButton.test.js
@@ -65,4 +65,11 @@ describe("OutlineButton", () => {
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
+
+  it("renders with full width", async () => {
+    const mountedComponent = mount(
+      <OutlineButton text="Test fullWidth Button" fullWidth />
+    );
+    expect(mountedComponent.find(".lab-btn--block")).toHaveLength(1);
+  });
 });

--- a/labsystem/src/Button/OutlineButton.test.js
+++ b/labsystem/src/Button/OutlineButton.test.js
@@ -58,4 +58,11 @@ describe("OutlineButton", () => {
     shallowedButton.simulate("click");
     expect(mockOnClick.mock.calls.length).toEqual(1);
   });
+
+  it("renders as expected if full width", async () => {
+    const renderedComponent = renderer
+      .create(<OutlineButton text="Test Outline fullWidth Button" fullWidth />)
+      .toJSON();
+    expect(renderedComponent).toMatchSnapshot();
+  });
 });

--- a/labsystem/src/Button/TextButton.test.js
+++ b/labsystem/src/Button/TextButton.test.js
@@ -60,4 +60,11 @@ describe("TextButton", () => {
       .toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
+
+  it("renders with full width", async () => {
+    const mountedComponent = mount(
+      <TextButton text="Test fullWidth Button" fullWidth />
+    );
+    expect(mountedComponent.find(".lab-btn--block")).toHaveLength(1);
+  });
 });

--- a/labsystem/src/Button/TextButton.test.js
+++ b/labsystem/src/Button/TextButton.test.js
@@ -53,4 +53,11 @@ describe("TextButton", () => {
     shallowedButton.simulate("click");
     expect(mockOnClick.mock.calls.length).toEqual(1);
   });
+
+  it("renders as expected if full width", async () => {
+    const renderedComponent = renderer
+      .create(<TextButton text="Test Text fullWidth Button" fullWidth />)
+      .toJSON();
+    expect(renderedComponent).toMatchSnapshot();
+  });
 });

--- a/labsystem/src/Button/__snapshots__/AbstractButton.test.js.snap
+++ b/labsystem/src/Button/__snapshots__/AbstractButton.test.js.snap
@@ -18,7 +18,7 @@ exports[`AbstractButton renders with base props for outline variant 1`] = `
   type="button"
 >
   
-  Test Default Button
+  Test Outline Button
 </button>
 `;
 
@@ -29,6 +29,6 @@ exports[`AbstractButton renders with base props for text variant 1`] = `
   type="button"
 >
   
-  Test Default Button
+  Test Text Button
 </button>
 `;

--- a/labsystem/src/Button/__snapshots__/Button.test.js.snap
+++ b/labsystem/src/Button/__snapshots__/Button.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Button renders as expected if full width 1`] = `
+<button
+  className="lab-btn lab-btn--default lab-btn--normal lab-btn--block"
+  onClick={[Function]}
+  type="button"
+>
+  
+  Test Default fullWidth Button
+</button>
+`;
+
 exports[`Button renders as expected when passing a small size 1`] = `
 <button
   className="lab-btn lab-btn--default lab-btn--small"

--- a/labsystem/src/Button/__snapshots__/OutlineButton.test.js.snap
+++ b/labsystem/src/Button/__snapshots__/OutlineButton.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`OutlineButton renders as expected if full width 1`] = `
+<button
+  className="lab-btn lab-btn--outline lab-btn--normal lab-btn--block"
+  onClick={[Function]}
+  type="button"
+>
+  
+  Test Outline fullWidth Button
+</button>
+`;
+
 exports[`OutlineButton renders as expected when passing a large size 1`] = `
 <button
   className="lab-btn lab-btn--outline lab-btn--large"

--- a/labsystem/src/Button/__snapshots__/TextButton.test.js.snap
+++ b/labsystem/src/Button/__snapshots__/TextButton.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextButton renders as expected if full width 1`] = `
+<button
+  className="lab-btn lab-btn--text lab-btn--normal lab-btn--block"
+  onClick={[Function]}
+  type="button"
+>
+  
+  Test Text fullWidth Button
+</button>
+`;
+
 exports[`TextButton renders as expected when passing a dark skin 1`] = `
 <button
   className="lab-btn lab-btn--text lab-btn--normal lab-btn--dark"

--- a/labsystem/src/Checkbox.test.js
+++ b/labsystem/src/Checkbox.test.js
@@ -4,6 +4,7 @@ import { mount } from "enzyme";
 import renderer from "react-test-renderer";
 
 import Checkbox from "./Checkbox";
+import Icon from "./Icon";
 
 describe("Checkbox", () => {
   const originalWarn = console.warn;
@@ -158,8 +159,8 @@ describe("Checkbox", () => {
     expect(renderedComponent).toMatchSnapshot();
   });
 
-  it("inits state.localChecked with defaultChecked if defined", async () => {
-    let component = mount(
+  it("initializes checked if defaultChecked is passed", async () => {
+    const mountedComponent = mount(
       <Checkbox
         name="test-checkbox"
         id="test-checkbox"
@@ -167,9 +168,20 @@ describe("Checkbox", () => {
         defaultChecked
       />
     );
-    expect(component.state().localChecked).toBe(true);
 
-    component = mount(
+    expect(
+      mountedComponent
+        .find(Icon)
+        .find("span")
+        .find(".lab-icon")
+        .find(".lab-icon--check")
+        .find(".lab-icon--white")
+        .find(".lab-icon--small")
+    ).toHaveLength(1);
+  });
+
+  it("initializes unchecked if defaultChecked is passed as false", async () => {
+    const mountedComponent = mount(
       <Checkbox
         name="test-checkbox"
         id="test-checkbox"
@@ -177,45 +189,81 @@ describe("Checkbox", () => {
         defaultChecked={false}
       />
     );
-    expect(component.state().localChecked).toBe(false);
 
-    component = mount(
+    expect(
+      mountedComponent.find(
+        Icon,
+        ".lab-icon",
+        ".lab-icon--check",
+        ".lab-icon--white",
+        ".lab-icon--small"
+      )
+    ).toHaveLength(0);
+  });
+
+  it("initializes unchecked if defaultChecked is not passed", async () => {
+    const mountedComponent = mount(
       <Checkbox name="test-checkbox" id="test-checkbox" label="test checkbox" />
     );
-    expect(component.state().localChecked).toBe(false);
+
+    expect(
+      mountedComponent.find(
+        Icon,
+        ".lab-icon",
+        ".lab-icon--check",
+        ".lab-icon--white",
+        ".lab-icon--small"
+      )
+    ).toHaveLength(0);
   });
 
   it("sets input as indeterminate", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <Checkbox name="test-checkbox" id="test-checkbox" label="test checkbox" />
     );
 
-    expect(component.find("input[indeterminate]").length).toBeFalsy();
+    expect(mountedComponent.find("input[indeterminate]").length).toBeFalsy();
 
-    component.setProps({ indeterminate: true });
-    component.update();
+    mountedComponent.setProps({ indeterminate: true });
+    mountedComponent.update();
 
-    expect(component.find("input[indeterminate]")).toBeTruthy();
+    expect(mountedComponent.find("input[indeterminate]")).toBeTruthy();
 
-    component.setProps({ indeterminate: undefined });
-    component.update();
+    mountedComponent.setProps({ indeterminate: undefined });
+    mountedComponent.update();
 
-    expect(component.find("input[indeterminate]").length).toBeFalsy();
+    expect(mountedComponent.find("input[indeterminate]").length).toBeFalsy();
   });
 
   it("changes state when input changes", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <Checkbox name="test-checkbox" id="test-checkbox" label="test checkbox" />
     );
 
-    expect(component.state().localChecked).toBe(false);
-    component.find("input").at(0).simulate("change");
-    expect(component.state().localChecked).toBe(true);
+    expect(
+      mountedComponent.find(
+        Icon,
+        ".lab-icon",
+        ".lab-icon--check",
+        ".lab-icon--white",
+        ".lab-icon--small"
+      )
+    ).toHaveLength(0);
+    mountedComponent.find("input").at(0).simulate("change");
+    expect(
+      mountedComponent
+        .find(Icon)
+        .find("span")
+        .find(".lab-icon")
+        .find(".lab-icon--check")
+        .find(".lab-icon--white")
+        .find(".lab-icon--small")
+    ).toHaveLength(1);
   });
 
   it("calls props.onChange passing event when input changes", async () => {
     const mockOnChange = jest.fn();
-    const component = mount(
+    const mountedComponent = mount(
       <Checkbox
         name="test-checkbox"
         id="test-checkbox"
@@ -224,12 +272,28 @@ describe("Checkbox", () => {
       />
     );
 
-    expect(component.state().localChecked).toBe(false);
+    expect(
+      mountedComponent.find(
+        Icon,
+        ".lab-icon",
+        ".lab-icon--check",
+        ".lab-icon--white",
+        ".lab-icon--small"
+      )
+    ).toHaveLength(0);
     expect(mockOnChange).not.toBeCalled();
 
-    component.find("input").at(0).simulate("change", { test: "event" });
+    mountedComponent.find("input").at(0).simulate("change", { test: "event" });
 
-    expect(component.state().localChecked).toBe(true);
+    expect(
+      mountedComponent
+        .find(Icon)
+        .find("span")
+        .find(".lab-icon")
+        .find(".lab-icon--check")
+        .find(".lab-icon--white")
+        .find(".lab-icon--small")
+    ).toHaveLength(1);
     expect(mockOnChange).toBeCalled();
   });
 });

--- a/labsystem/src/Checkbox.test.js
+++ b/labsystem/src/Checkbox.test.js
@@ -169,6 +169,8 @@ describe("Checkbox", () => {
       />
     );
 
+    // eslint-disable-next-line prettier/prettier
+    expect(mountedComponent.find("input").find({ checked: true })).toHaveLength(1);
     expect(
       mountedComponent
         .find(Icon)
@@ -191,6 +193,9 @@ describe("Checkbox", () => {
     );
 
     expect(
+      mountedComponent.find("input").find({ checked: false })
+    ).toHaveLength(1);
+    expect(
       mountedComponent.find(
         Icon,
         ".lab-icon",
@@ -206,6 +211,9 @@ describe("Checkbox", () => {
       <Checkbox name="test-checkbox" id="test-checkbox" label="test checkbox" />
     );
 
+    expect(
+      mountedComponent.find("input").find({ checked: false })
+    ).toHaveLength(1);
     expect(
       mountedComponent.find(
         Icon,
@@ -241,6 +249,9 @@ describe("Checkbox", () => {
     );
 
     expect(
+      mountedComponent.find("input").find({ checked: false })
+    ).toHaveLength(1);
+    expect(
       mountedComponent.find(
         Icon,
         ".lab-icon",
@@ -250,6 +261,8 @@ describe("Checkbox", () => {
       )
     ).toHaveLength(0);
     mountedComponent.find("input").at(0).simulate("change");
+    // eslint-disable-next-line prettier/prettier
+    expect(mountedComponent.find("input").find({ checked: true })).toHaveLength(1);
     expect(
       mountedComponent
         .find(Icon)
@@ -273,6 +286,9 @@ describe("Checkbox", () => {
     );
 
     expect(
+      mountedComponent.find("input").find({ checked: false })
+    ).toHaveLength(1);
+    expect(
       mountedComponent.find(
         Icon,
         ".lab-icon",
@@ -285,6 +301,8 @@ describe("Checkbox", () => {
 
     mountedComponent.find("input").at(0).simulate("change", { test: "event" });
 
+    // eslint-disable-next-line prettier/prettier
+    expect(mountedComponent.find("input").find({ checked: true })).toHaveLength(1);
     expect(
       mountedComponent
         .find(Icon)

--- a/labsystem/src/Input/PasswordInput.test.js
+++ b/labsystem/src/Input/PasswordInput.test.js
@@ -19,32 +19,35 @@ describe("PasswordInput", () => {
   });
 
   it("renders as type=password", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput id="testInput" label="Test Input" />
     );
-    expect(component.find("input[type='password']")).toHaveLength(1);
+    expect(mountedComponent.find("input[type='password']")).toHaveLength(1);
   });
 
   it("toggles password visibility when clicking the trailing icon", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput id="testInput" label="Test Input" />
     );
 
-    expect(component.state().showPassword).toBe(false);
-    const trailingIcon = component.find("Icon[type='eye-closed']");
+    expect(
+      mountedComponent.find("input").find({ type: "password" })
+    ).toHaveLength(1);
+    const trailingIcon = mountedComponent.find("Icon[type='eye-closed']");
     expect(trailingIcon).toHaveLength(1);
 
     trailingIcon.at(0).simulate("click");
 
-    expect(component.state().showPassword).toBe(true);
-    expect(component.find("input[type='text']")).toHaveLength(1);
-    expect(component.find("Icon[type='eye-opened']")).toHaveLength(1);
+    expect(mountedComponent.find("input").find({ type: "text" })).toHaveLength(
+      1
+    );
+    expect(mountedComponent.find("Icon[type='eye-opened']")).toHaveLength(1);
   });
 
   it("raises console.warn and sets state with value when passing value and defaultValue by props at the same time", async () => {
     console.warn = jest.fn();
 
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput
         id="testInput"
         label="Test Input"
@@ -54,33 +57,33 @@ describe("PasswordInput", () => {
     );
 
     expect(console.warn).toBeCalled();
-    const inputElement = component.find("input");
+    const inputElement = mountedComponent.find("input");
     expect(inputElement.render().attr("value")).toBe("test value");
   });
 
   it("sets state with value if it is passed by props", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput id="testInput" label="Test Input" value="test value" />
     );
 
-    const inputElement = component.find("input");
+    const inputElement = mountedComponent.find("input");
     expect(inputElement.render().attr("value")).toBe("test value");
   });
 
   it("sets state with defaultValue if it is passed by props and value is not passed by props", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput
         id="testInput"
         label="Test Input"
         defaultValue="default value"
       />
     );
-    const inputElement = component.find("input");
+    const inputElement = mountedComponent.find("input");
     expect(inputElement.render().attr("value")).toBe("default value");
   });
 
   it("sets state with isValid if it is passed by props", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput
         id="testInput"
         label="Test Input"
@@ -88,11 +91,11 @@ describe("PasswordInput", () => {
         isValid={false}
       />
     );
-    expect(component.find(".lab-input--invalid")).toHaveLength(1);
+    expect(mountedComponent.find(".lab-input--invalid")).toHaveLength(1);
   });
 
   it("sets localIsValid to true if value is valid and change it if value validity changes", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput
         id="testInput"
         label="Test Input"
@@ -100,21 +103,21 @@ describe("PasswordInput", () => {
         required
       />
     );
-    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+    expect(mountedComponent.find(".lab-input--invalid")).toHaveLength(0);
 
-    component.setProps({ value: "" });
-    component.update();
+    mountedComponent.setProps({ value: "" });
+    mountedComponent.update();
 
-    expect(component.find(".lab-input--invalid")).toHaveLength(1);
+    expect(mountedComponent.find(".lab-input--invalid")).toHaveLength(1);
 
-    component.setProps({ value: "valid@value.com" });
-    component.update();
+    mountedComponent.setProps({ value: "valid@value.com" });
+    mountedComponent.update();
 
-    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+    expect(mountedComponent.find(".lab-input--invalid")).toHaveLength(0);
   });
 
   it("shows help text", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput
         id="testInput"
         label="Test Input"
@@ -124,20 +127,20 @@ describe("PasswordInput", () => {
       />
     );
 
-    expect(component.find(".lab-input__message--required").text()).toBe(
+    expect(mountedComponent.find(".lab-input__message--required").text()).toBe(
       "help message"
     );
 
-    component.setProps({ value: "" });
-    component.update();
+    mountedComponent.setProps({ value: "" });
+    mountedComponent.update();
 
-    expect(component.find(".lab-input__message--error").text()).toBe(
+    expect(mountedComponent.find(".lab-input__message--error").text()).toBe(
       "help message"
     );
   });
 
   it("shows custom error message when input is invalid", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput
         id="testInput"
         label="Test Input"
@@ -147,18 +150,18 @@ describe("PasswordInput", () => {
       />
     );
 
-    expect(component.find(".lab-input__message--error")).toHaveLength(0);
+    expect(mountedComponent.find(".lab-input__message--error")).toHaveLength(0);
 
-    component.setProps({ value: "" });
-    component.update();
+    mountedComponent.setProps({ value: "" });
+    mountedComponent.update();
 
-    expect(component.find(".lab-input__message--error").text()).toBe(
+    expect(mountedComponent.find(".lab-input__message--error").text()).toBe(
       "error message"
     );
   });
 
   it("changes localValue state when input changes", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput
         id="testInput"
         label="Test Input"
@@ -168,10 +171,10 @@ describe("PasswordInput", () => {
       />
     );
 
-    const inputElement = component.find("input");
+    const inputElement = mountedComponent.find("input");
     expect(inputElement.render().attr("value")).toBe("truthy value");
 
-    component
+    mountedComponent
       .find("input")
       .at(0)
       .simulate("change", {
@@ -186,7 +189,7 @@ describe("PasswordInput", () => {
   });
 
   it("sets input as invalid if it is required and is not filled, even if isValid is passed by props as true", async () => {
-    const component = mount(
+    const mountedComponent = mount(
       <PasswordInput
         id="testInput"
         label="Test Input"
@@ -196,9 +199,9 @@ describe("PasswordInput", () => {
       />
     );
 
-    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+    expect(mountedComponent.find(".lab-input--invalid")).toHaveLength(0);
 
-    component
+    mountedComponent
       .find("input")
       .at(0)
       .simulate("change", {
@@ -209,9 +212,9 @@ describe("PasswordInput", () => {
         },
       });
 
-    expect(component.find(".lab-input--invalid")).toHaveLength(0);
+    expect(mountedComponent.find(".lab-input--invalid")).toHaveLength(0);
 
-    component
+    mountedComponent
       .find("input")
       .at(0)
       .simulate("change", {
@@ -222,7 +225,7 @@ describe("PasswordInput", () => {
         },
       });
 
-    expect(component.find(".lab-input--invalid")).toHaveLength(1);
+    expect(mountedComponent.find(".lab-input--invalid")).toHaveLength(1);
   });
 
   it("renders prefix when it is passed by props", async () => {

--- a/labsystem/src/Toggle.test.js
+++ b/labsystem/src/Toggle.test.js
@@ -1,16 +1,15 @@
 /* eslint-disable no-console */
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import renderer from "react-test-renderer";
 
 import Toggle from "./Toggle";
 
 describe("Toggle", () => {
   it("renders with base props", async () => {
-    expect(shallow(<Toggle name="test-toggle" />)).toBeTruthy();
-    const renderedComponent = renderer
-      .create(<Toggle name="test-toggle" />)
-      .toJSON();
+    const component = <Toggle name="test-toggle" />;
+    expect(mount(component)).toBeTruthy();
+    const renderedComponent = renderer.create(component).toJSON();
     expect(renderedComponent).toMatchSnapshot();
   });
 
@@ -28,37 +27,45 @@ describe("Toggle", () => {
     expect(renderedComponent).toMatchSnapshot();
   });
 
-  it("inits state.localValue with defaultValue if defined", async () => {
-    let component = shallow(<Toggle name="test-toggle" defaultValue />);
-    expect(component.state().localValue).toBe(true);
+  it("initializes toggled if defaultValue is passed", async () => {
+    const mountedComponent = mount(<Toggle name="test-toggle" defaultValue />);
+    expect(mountedComponent.find({ checked: true })).toHaveLength(1);
+  });
 
-    component = shallow(<Toggle name="test-toggle" defaultValue={false} />);
-    expect(component.state().localValue).toBe(false);
+  it("initializes untoggled if defaultValue is passed as false", async () => {
+    const mountedComponent = mount(
+      <Toggle name="test-toggle" defaultValue={false} />
+    );
+    expect(mountedComponent.find({ checked: false })).toHaveLength(1);
+  });
 
-    component = shallow(<Toggle name="test-toggle" />);
-    expect(component.state().localValue).toBe(false);
+  it("initializes untoggled if defaultValue is not passed", async () => {
+    const mountedComponent = mount(<Toggle name="test-toggle" />);
+    expect(mountedComponent.find({ checked: false })).toHaveLength(1);
   });
 
   it("changes state when input changes", async () => {
-    const component = shallow(<Toggle name="test-toggle" />);
+    const mountedComponent = mount(<Toggle name="test-toggle" />);
 
-    expect(component.state().localValue).toBe(false);
-    component.find("input").at(0).simulate("change");
-    expect(component.state().localValue).toBe(true);
+    expect(mountedComponent.find({ checked: false })).toHaveLength(1);
+    mountedComponent.find("input").at(0).simulate("change");
+    expect(mountedComponent.find({ checked: true })).toHaveLength(1);
   });
 
   it("calls props.handleToggle passing event when input changes", async () => {
     const mockHandleToggle = jest.fn();
-    const component = shallow(
+    const mountedComponent = mount(
       <Toggle name="test-toggle" handleToggle={mockHandleToggle} />
     );
 
-    expect(component.state().localValue).toBe(false);
+    expect(mountedComponent.find({ checked: false })).toHaveLength(1);
     expect(mockHandleToggle).not.toBeCalled();
 
-    component.find("input").at(0).simulate("change", { test: "event" });
+    mountedComponent.find("input").at(0).simulate("change", { test: "event" });
 
-    expect(component.state().localValue).toBe(true);
-    expect(mockHandleToggle).toBeCalledWith({ test: "event" });
+    expect(mountedComponent.find({ checked: true })).toHaveLength(1);
+    expect(mockHandleToggle).toBeCalledWith(
+      expect.objectContaining({ test: "event" })
+    );
   });
 });


### PR DESCRIPTION
**Link to tasks**
https://labcodes.atlassian.net/browse/DSYS-157
https://labcodes.atlassian.net/browse/DSYS-161

**Description**
This PR implements tests for checking full width buttons.
Also in this PR, all references to `component.states()` are removed from the test codebase. That includes 17 tests across 3 test files:
- 7 times for `Checkbox` (to `localChecked`);
- 7 times for `Toggle` (to `localValue`);
- 2 times for `PasswordInput` (to `showPassword`).
In the files mentioned above, variables named as `component` are renamed to `renderedComponent` or `mountedComponent` for an improved readability.
Lastly, in the files mentioned above, the `mount` enzyme method is preferred instead of `shallow`.

**How to test**
From the labsystem dir, run `npm test`. Check if all tests pass.