### PR TITLE
Add ids to toggles on playgrounds

### DIFF
--- a/playgrounds/ButtonPlayground.js
+++ b/playgrounds/ButtonPlayground.js
@@ -235,6 +235,7 @@ export default class ButtonPlayground extends React.Component {
               <strong>full width</strong>
             </p>
             <Toggle
+              id="fullWidth"
               name="fullWidth"
               value={fullWidth}
               handleToggle={this.handlePropChangeBool}
@@ -246,6 +247,7 @@ export default class ButtonPlayground extends React.Component {
               <strong>ariaDisabled</strong>
             </p>
             <Toggle
+              id="selectedAriaDisabled"
               name="selectedAriaDisabled"
               value={selectedAriaDisabled}
               handleToggle={this.handlePropChangeBool}
@@ -257,6 +259,7 @@ export default class ButtonPlayground extends React.Component {
               <strong>disabled</strong>
             </p>
             <Toggle
+              id="selectedIsDisabled"
               name="selectedIsDisabled"
               value={selectedIsDisabled}
               handleToggle={this.handlePropChangeBool}

--- a/playgrounds/CardPlayground.js
+++ b/playgrounds/CardPlayground.js
@@ -289,6 +289,7 @@ export default class CardPlayground extends React.Component {
             isHorizontal
             <br />
             <Toggle
+              id="cardIsHorizontal"
               name="cardIsHorizontal"
               value={cardIsHorizontal}
               handleToggle={() => this.handleToggleFor("cardIsHorizontal")}
@@ -299,6 +300,7 @@ export default class CardPlayground extends React.Component {
             isCompact
             <br />
             <Toggle
+              id="cardIsCompact"
               name="cardIsCompact"
               value={cardIsCompact}
               handleToggle={() => this.handleToggleFor("cardIsCompact")}
@@ -327,6 +329,7 @@ export default class CardPlayground extends React.Component {
               isOverflowed
               <br />
               <Toggle
+                id="cardImageIsOverflowed"
                 name="cardImageIsOverflowed"
                 value={cardImageIsOverflowed}
                 handleToggle={() =>
@@ -340,6 +343,7 @@ export default class CardPlayground extends React.Component {
             Show it above the CardHeader
             <br />
             <Toggle
+              id="cardImageIsAboveHeader"
               name="cardImageIsAboveHeader"
               value={cardImageIsAboveHeader}
               handleToggle={() =>
@@ -371,6 +375,7 @@ export default class CardPlayground extends React.Component {
 
               <div className="lab-playground__item">
                 <Toggle
+                  id="cardHeaderIsOverlay"
                   name="cardHeaderIsOverlay"
                   value={cardHeaderIsOverlay}
                   handleToggle={() =>
@@ -433,6 +438,7 @@ export default class CardPlayground extends React.Component {
             isOverflowed
             <br />
             <Toggle
+              id="cardDividerIsOverflowed"
               name="cardDividerIsOverflowed"
               value={cardDividerIsOverflowed}
               handleToggle={() =>
@@ -445,6 +451,7 @@ export default class CardPlayground extends React.Component {
             Show divider
             <br />
             <Toggle
+              id="showDivider"
               name="showDivider"
               value={showDivider}
               handleToggle={() => this.handleToggleFor("showDivider")}
@@ -490,6 +497,7 @@ export default class CardPlayground extends React.Component {
             Show Card Actions
             <br />
             <Toggle
+              id="showCardActions"
               name="showCardActions"
               value={showCardActions}
               handleToggle={() => this.handleToggleFor("showCardActions")}
@@ -501,6 +509,7 @@ export default class CardPlayground extends React.Component {
               openNewTab
               <br />
               <Toggle
+                id="cardActionOpenNewTab"
                 name="cardActionOpenNewTab"
                 value={cardActionOpenNewTab}
                 handleToggle={() =>
@@ -516,6 +525,7 @@ export default class CardPlayground extends React.Component {
                 isHorizontal
                 <br />
                 <Toggle
+                  id="cardActionIsHorizontal"
                   name="cardActionIsHorizontal"
                   value={cardActionIsHorizontal}
                   handleToggle={() =>
@@ -527,6 +537,7 @@ export default class CardPlayground extends React.Component {
                 isText
                 <br />
                 <Toggle
+                  id="cardActionIsText"
                   name="cardActionIsText"
                   value={cardActionIsText}
                   handleToggle={() => this.handleToggleFor("cardActionIsText")}
@@ -536,6 +547,7 @@ export default class CardPlayground extends React.Component {
                 Disable buttons
                 <br />
                 <Toggle
+                  id="cardActionButtonsAreDisabled"
                   name="cardActionButtonsAreDisabled"
                   value={cardActionButtonsAreDisabled}
                   handleToggle={() =>

--- a/playgrounds/CheckboxPlayground.js
+++ b/playgrounds/CheckboxPlayground.js
@@ -74,7 +74,12 @@ export default class CheckboxPlayground extends React.Component {
               <p>
                 <strong>Disabled</strong>
               </p>
-              <Toggle name="disabled" handleToggle={this.handlePropBool} />
+              <Toggle
+                id="disabled"
+                name="disabled"
+                value={disabled}
+                handleToggle={this.handlePropBool}
+              />
             </span>
             <span className="lab-playground__item">
               <fieldset>

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -219,6 +219,7 @@ export default class DialogPlayground extends React.Component {
                   <strong>isModal</strong>
                 </p>
                 <Toggle
+                  id="selectedIsModal"
                   name="selectedIsModal"
                   label="selectedIsModal"
                   value={selectedIsModal}
@@ -233,6 +234,7 @@ export default class DialogPlayground extends React.Component {
               <strong>isLarge</strong>
             </p>
             <Toggle
+              id="selectedIsLarge"
               name="selectedIsLarge"
               label="selectedIsLarge"
               value={selectedIsLarge}

--- a/playgrounds/NarrowSidebarPlayground.js
+++ b/playgrounds/NarrowSidebarPlayground.js
@@ -208,6 +208,7 @@ export default class NarrowSidebarPlayground extends React.Component {
             isVivid
             <br />
             <Toggle
+              id="isVivid"
               name="isVivid"
               label="isVivid"
               value={isVivid}
@@ -218,6 +219,7 @@ export default class NarrowSidebarPlayground extends React.Component {
             withDividers
             <br />
             <Toggle
+              id="withDividers"
               name="withDividers"
               label="withDividers"
               value={withDividers}
@@ -228,6 +230,7 @@ export default class NarrowSidebarPlayground extends React.Component {
             Show avatar in the header
             <br />
             <Toggle
+              id="useAvatarInHeader"
               name="useAvatarInHeader"
               label="useAvatarInHeader"
               value={useAvatarInHeader}

--- a/playgrounds/RadioPlayground.js
+++ b/playgrounds/RadioPlayground.js
@@ -106,16 +106,18 @@ export default class RadioPlayground extends React.Component {
                 <strong>Disable Option 1</strong>
               </p>
               <Toggle
-                value={disabled1}
+                id="disabled1"
                 name="disabled1"
+                value={disabled1}
                 handleToggle={this.handleDisabled1}
               />
               <p>
                 <strong>Disable Option 2</strong>
               </p>
               <Toggle
-                value={disabled2}
+                id="disabled2"
                 name="disabled2"
+                value={disabled2}
                 handleToggle={this.handleDisabled2}
               />
             </span>

--- a/playgrounds/TagPlayground.js
+++ b/playgrounds/TagPlayground.js
@@ -241,6 +241,7 @@ export default class TagPlayground extends React.Component {
                     <strong>Disabled</strong>
                   </p>
                   <Toggle
+                    id="selectedIsDisabled"
                     name="selectedIsDisabled"
                     handleToggle={this.handleBoolPropChange}
                     value={selectedIsDisabled}
@@ -249,6 +250,7 @@ export default class TagPlayground extends React.Component {
                     <strong>AriaDisabled</strong>
                   </p>
                   <Toggle
+                    id="selectedAriaDisabled"
                     name="selectedAriaDisabled"
                     handleToggle={this.handleBoolPropChange}
                     value={selectedAriaDisabled}
@@ -259,6 +261,7 @@ export default class TagPlayground extends React.Component {
                 <strong>isOutline</strong>
               </p>
               <Toggle
+                id="selectedIsOutline"
                 name="selectedIsOutline"
                 handleToggle={this.handleBoolPropChange}
                 value={selectedIsOutline}

--- a/playgrounds/TextInputPlayground.js
+++ b/playgrounds/TextInputPlayground.js
@@ -256,30 +256,34 @@ export default class TextInputPlayground extends React.Component {
               <strong>Required</strong>
             </p>
             <Toggle
-              value={required}
+              id="required"
               name="required"
+              value={required}
               handleToggle={this.handlePropChangeBool}
             />
             <p>
               <strong>Disabled</strong>
             </p>
             <Toggle
-              value={disabled}
+              id="disabled"
               name="disabled"
+              value={disabled}
               handleToggle={this.handlePropChangeBool}
             />
             <p>
               <strong>AriaDisabled</strong>
             </p>
             <Toggle
-              value={ariaDisabled}
+              id="ariaDisabled"
               name="ariaDisabled"
+              value={ariaDisabled}
               handleToggle={this.handlePropChangeBool}
             />
             <p>
               <strong>isValid</strong>
             </p>
             <Toggle
+              id="isValid"
               name="isValid"
               value={isValid}
               handleToggle={this.handlePropChangeBool}


### PR DESCRIPTION
**Link to task:** https://labcodes.atlassian.net/browse/DSYS-217

**Staging app:** https://fix-playground-toggles--labstorybook-master.netlify.app/

**How to test:** Open the staging app and verify that all toggles present in playgrounds work as intended.

**Description of your solution:** Toggles previously used `name` as `id`, but since the change, `id` is independent. Adding `id`s back makes clicking the toggle's labels change the value of the toggle, effectively fixing them.
