### PR TITLE
Playground improvements qa

### DIFF
--- a/labsystem/samples/SampleComponent.stories.mdx
+++ b/labsystem/samples/SampleComponent.stories.mdx
@@ -42,7 +42,7 @@ import { thumbSrcOptions, iconOptions } from "../playgrounds/assets";
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options.</p>
+  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
   {/* <SamplePlayground /> */}
 
   <h2>Prop API</h2>

--- a/labsystem/samples/SampleComponent.stories.mdx
+++ b/labsystem/samples/SampleComponent.stories.mdx
@@ -42,7 +42,7 @@ import { thumbSrcOptions, iconOptions } from "../playgrounds/assets";
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
+  <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
   {/* <SamplePlayground /> */}
 
   <h2>Prop API</h2>

--- a/playgrounds/ButtonPlayground.js
+++ b/playgrounds/ButtonPlayground.js
@@ -129,8 +129,6 @@ export default class ButtonPlayground extends React.Component {
         </div>
 
         <div className="column lab-playground__configs">
-          <h3>Prop Settings</h3>
-
           <div className="lab-playground__item">
             <fieldset>
               <legend>Variation</legend>

--- a/playgrounds/ButtonPlayground.js
+++ b/playgrounds/ButtonPlayground.js
@@ -4,7 +4,7 @@ import { isEmpty } from "lodash";
 import Radio from "../labsystem/src/Radio";
 import TextInput from "../labsystem/src/Input/TextInput";
 import { Button, OutlineButton, TextButton } from "../labsystem/src/Button";
-import { iconOptions, buttonSkinOptions } from "./assets";
+import { iconOptions, buttonSkinOptions, skinsWithBackground } from "./assets";
 import Toggle from "../labsystem/src/Toggle";
 
 export default class ButtonPlayground extends React.Component {
@@ -119,7 +119,11 @@ export default class ButtonPlayground extends React.Component {
       <div className="columns lab-playground">
         <div
           className="column lab-playground__component"
-          style={selectedSkin === "light" ? { background: "#2E3942" } : {}}
+          style={
+            skinsWithBackground.includes(selectedSkin)
+              ? { background: "#2E3942" }
+              : {}
+          }
         >
           {this.renderCurrentComponent()}
         </div>

--- a/playgrounds/CardPlayground.js
+++ b/playgrounds/CardPlayground.js
@@ -245,8 +245,6 @@ export default class CardPlayground extends React.Component {
           {this.renderCurrentComponent()}
         </div>
         <div className="column lab-playground__configs">
-          <h3>Prop Settings</h3>
-
           <h4>Card Style</h4>
           <span className="lab-playground__item">
             <fieldset>

--- a/playgrounds/CardPlayground.js
+++ b/playgrounds/CardPlayground.js
@@ -245,7 +245,7 @@ export default class CardPlayground extends React.Component {
           {this.renderCurrentComponent()}
         </div>
         <div className="column lab-playground__configs">
-          <h4>Card Style</h4>
+          <h3>Card Style</h3>
           <span className="lab-playground__item">
             <fieldset>
               <legend>Variation</legend>
@@ -324,7 +324,7 @@ export default class CardPlayground extends React.Component {
             </fieldset>
           </span>
 
-          <h4>CardHeader</h4>
+          <h3>CardHeader</h3>
           <span className="lab-playground__item">
             <fieldset>
               <legend>isOverlay</legend>
@@ -429,7 +429,7 @@ export default class CardPlayground extends React.Component {
             </fieldset>
           </span>
 
-          <h4>CardImage</h4>
+          <h3>CardImage</h3>
           <span className="lab-playground__inline-item">
             <fieldset>
               <legend>Show image</legend>
@@ -475,7 +475,7 @@ export default class CardPlayground extends React.Component {
             </fieldset>
           </span>
 
-          <h4>Content</h4>
+          <h3>Content</h3>
           <span className="lab-playground__item" style={{ width: "100%" }}>
             <label htmlFor="cardBodyHTML">
               Children
@@ -493,7 +493,7 @@ export default class CardPlayground extends React.Component {
             </label>
           </span>
 
-          <h4>CardDivider</h4>
+          <h3>CardDivider</h3>
           <span className="lab-playground__inline-item">
             <fieldset>
               <legend>Show divider</legend>
@@ -521,7 +521,7 @@ export default class CardPlayground extends React.Component {
             </fieldset>
           </span>
 
-          <h4>CardAction</h4>
+          <h3>CardAction</h3>
           <span className="lab-playground__item">
             <fieldset>
               <legend>Show Card Actions</legend>

--- a/playgrounds/CheckboxPlayground.js
+++ b/playgrounds/CheckboxPlayground.js
@@ -53,7 +53,6 @@ export default class CheckboxPlayground extends React.Component {
           </div>
 
           <div className="column lab-playground__configs">
-            <h3>Prop Settings</h3>
             <span className="lab-playground__item">
               <TextInput
                 label="Label"

--- a/playgrounds/DialogPlayground.js
+++ b/playgrounds/DialogPlayground.js
@@ -147,8 +147,6 @@ export default class DialogPlayground extends React.Component {
         </div>
 
         <div className="column lab-playground__configs">
-          <h3>Prop Settings</h3>
-
           <span className="lab-playground__inline-item">
             <label htmlFor="currentComponent">
               Variation

--- a/playgrounds/NarrowSidebarPlayground.js
+++ b/playgrounds/NarrowSidebarPlayground.js
@@ -238,192 +238,145 @@ export default class NarrowSidebarPlayground extends React.Component {
               />
             </fieldset>
           </span>
-          <span
-            className="lab-playground__item"
-            onClick={() => this.handleToggleFor("showHeaderConfigs")}
-            onKeyPress={() => this.handleToggleFor("showHeaderConfigs")}
-            style={{ cursor: "pointer", display: "flex", alignItems: "center" }}
-            role="button"
-          >
-            <h4>Header</h4>
-            <Icon
-              type={showHeaderConfigs ? "collapse-open" : "collapse-closed"}
+          <h4>Header</h4>
+          <React.Fragment>
+            <span className="lab-playground__item">
+              <TextInput
+                id="avatarSrc"
+                label="avatarSrc"
+                value={avatarSrc}
+                onChange={this.handlePropChangeText}
+                required
+              />
+            </span>
+            <span className="lab-playground__item">
+              <TextInput
+                id="avatarAltText"
+                label="avatarAltText"
+                value={avatarAltText}
+                onChange={this.handlePropChangeText}
+                required
+              />
+            </span>
+            <span className="lab-playground__item">
+              <TextInput
+                id="avatarCaption"
+                label="avatarCaption"
+                value={avatarCaption}
+                onChange={this.handlePropChangeText}
+                required
+              />
+            </span>
+          </React.Fragment>
+          <React.Fragment>
+            <span className="lab-playground__item">
+              <TextInput
+                id="logoSrc"
+                label="logoSrc"
+                value={logoSrc}
+                onChange={this.handlePropChangeText}
+                required
+              />
+            </span>
+            <span className="lab-playground__item">
+              <TextInput
+                id="logoAltText"
+                label="logoAltText"
+                value={logoAltText}
+                onChange={this.handlePropChangeText}
+                required
+              />
+            </span>
+          </React.Fragment>
+          <h4>Body</h4>
+          <React.Fragment>
+            <span className="lab-playground__item">
+              <TextInput
+                id="itemIcon"
+                label="itemIcon"
+                value={itemIcon}
+                onChange={this.handlePropChangeText}
+              />
+            </span>
+            <span className="lab-playground__item">
+              <TextInput
+                id="itemLabel"
+                label="itemLabel"
+                value={itemLabel}
+                onChange={this.handlePropChangeText}
+                required
+              />
+            </span>
+            <Button
+              text="Add item"
+              size="normal"
+              onClick={this.addNewItem}
             />
-          </span>
-          {showHeaderConfigs && useAvatarInHeader ? (
-            <React.Fragment>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="avatarSrc"
-                  label="avatarSrc"
-                  value={avatarSrc}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="avatarAltText"
-                  label="avatarAltText"
-                  value={avatarAltText}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="avatarCaption"
-                  label="avatarCaption"
-                  value={avatarCaption}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-            </React.Fragment>
-          ) : null}
-          {showHeaderConfigs && !useAvatarInHeader ? (
-            <React.Fragment>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="logoSrc"
-                  label="logoSrc"
-                  value={logoSrc}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="logoAltText"
-                  label="logoAltText"
-                  value={logoAltText}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-            </React.Fragment>
-          ) : null}
-          <span
-            className="lab-playground__item"
-            onClick={() => this.handleToggleFor("showBodyConfigs")}
-            onKeyPress={() => this.handleToggleFor("showBodyConfigs")}
-            style={{ cursor: "pointer", display: "flex", alignItems: "center" }}
-            role="button"
-          >
-            <h4>Body</h4>
-            <Icon
-              type={showBodyConfigs ? "collapse-open" : "collapse-closed"}
+            <OutlineButton
+              text="Remove last item"
+              size="normal"
+              onClick={this.removeLastItem}
             />
-          </span>
-          {showBodyConfigs ? (
-            <React.Fragment>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="itemIcon"
-                  label="itemIcon"
-                  value={itemIcon}
-                  onChange={this.handlePropChangeText}
-                />
-              </span>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="itemLabel"
-                  label="itemLabel"
-                  value={itemLabel}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-              <Button
-                text="Add item"
-                size="normal"
-                onClick={this.addNewItem}
+          </React.Fragment>
+          <h4>Footer</h4>
+          <React.Fragment>
+            <span className="lab-playground__item">
+              <TextInput
+                id="avatarSrc"
+                label="avatarSrc"
+                value={avatarSrc}
+                onChange={this.handlePropChangeText}
+                required
               />
-              <OutlineButton
-                text="Remove last item"
-                size="normal"
-                onClick={this.removeLastItem}
+            </span>
+            <span className="lab-playground__item">
+              <TextInput
+                id="avatarAltText"
+                label="avatarAltText"
+                value={avatarAltText}
+                onChange={this.handlePropChangeText}
+                required
               />
-            </React.Fragment>
-          ) : (
-            ""
-          )}
-          <span
-            className="lab-playground__item"
-            onClick={() => this.handleToggleFor("showFooterConfigs")}
-            onKeyPress={() => this.handleToggleFor("showFooterConfigs")}
-            style={{ cursor: "pointer", display: "flex", alignItems: "center" }}
-            role="button"
-          >
-            <h4>Footer</h4>
-            <Icon
-              type={showFooterConfigs ? "collapse-open" : "collapse-closed"}
+            </span>
+            <span className="lab-playground__item">
+              <TextInput
+                id="avatarCaption"
+                label="avatarCaption"
+                value={avatarCaption}
+                onChange={this.handlePropChangeText}
+                required
+              />
+            </span>
+          </React.Fragment>
+          <React.Fragment>
+            <span className="lab-playground__item">
+              <TextInput
+                id="footerButtonIcon"
+                label="footerButtonIcon"
+                value={footerButtonIcon}
+                onChange={this.handlePropChangeText}
+              />
+            </span>
+            <span className="lab-playground__item">
+              <TextInput
+                id="footerButtonLabel"
+                label="footerButtonLabel"
+                value={footerButtonLabel}
+                onChange={this.handlePropChangeText}
+                required
+              />
+            </span>
+            <Button
+              text="Add footer button"
+              size="normal"
+              onClick={this.addNewFooterButton}
             />
-          </span>
-          {showFooterConfigs && !useAvatarInHeader ? (
-            <React.Fragment>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="avatarSrc"
-                  label="avatarSrc"
-                  value={avatarSrc}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="avatarAltText"
-                  label="avatarAltText"
-                  value={avatarAltText}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="avatarCaption"
-                  label="avatarCaption"
-                  value={avatarCaption}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-            </React.Fragment>
-          ) : null}
-          {showFooterConfigs ? (
-            <React.Fragment>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="footerButtonIcon"
-                  label="footerButtonIcon"
-                  value={footerButtonIcon}
-                  onChange={this.handlePropChangeText}
-                />
-              </span>
-              <span className="lab-playground__item">
-                <TextInput
-                  id="footerButtonLabel"
-                  label="footerButtonLabel"
-                  value={footerButtonLabel}
-                  onChange={this.handlePropChangeText}
-                  required
-                />
-              </span>
-              <Button
-                text="Add footer button"
-                size="normal"
-                onClick={this.addNewFooterButton}
-              />
-              <OutlineButton
-                text="Remove last footer button"
-                size="normal"
-                onClick={this.removeLastFooterButton}
-              />
-            </React.Fragment>
-          ) : (
-            ""
-          )}
+            <OutlineButton
+              text="Remove last footer button"
+              size="normal"
+              onClick={this.removeLastFooterButton}
+            />
+          </React.Fragment>
         </div>
       </div>
     );

--- a/playgrounds/NarrowSidebarPlayground.js
+++ b/playgrounds/NarrowSidebarPlayground.js
@@ -201,7 +201,6 @@ export default class NarrowSidebarPlayground extends React.Component {
           </div>
         </div>
         <div className="column lab-playground__configs">
-          <h3>Prop Settings</h3>
           <span className="lab-playground__inline-item">
             <fieldset>
               <legend>isVivid</legend>

--- a/playgrounds/NarrowSidebarPlayground.js
+++ b/playgrounds/NarrowSidebarPlayground.js
@@ -238,56 +238,6 @@ export default class NarrowSidebarPlayground extends React.Component {
               />
             </fieldset>
           </span>
-          <h4>Header</h4>
-          <React.Fragment>
-            <span className="lab-playground__item">
-              <TextInput
-                id="avatarSrc"
-                label="avatarSrc"
-                value={avatarSrc}
-                onChange={this.handlePropChangeText}
-                required
-              />
-            </span>
-            <span className="lab-playground__item">
-              <TextInput
-                id="avatarAltText"
-                label="avatarAltText"
-                value={avatarAltText}
-                onChange={this.handlePropChangeText}
-                required
-              />
-            </span>
-            <span className="lab-playground__item">
-              <TextInput
-                id="avatarCaption"
-                label="avatarCaption"
-                value={avatarCaption}
-                onChange={this.handlePropChangeText}
-                required
-              />
-            </span>
-          </React.Fragment>
-          <React.Fragment>
-            <span className="lab-playground__item">
-              <TextInput
-                id="logoSrc"
-                label="logoSrc"
-                value={logoSrc}
-                onChange={this.handlePropChangeText}
-                required
-              />
-            </span>
-            <span className="lab-playground__item">
-              <TextInput
-                id="logoAltText"
-                label="logoAltText"
-                value={logoAltText}
-                onChange={this.handlePropChangeText}
-                required
-              />
-            </span>
-          </React.Fragment>
           <h4>Body</h4>
           <React.Fragment>
             <span className="lab-playground__item">
@@ -319,35 +269,6 @@ export default class NarrowSidebarPlayground extends React.Component {
             />
           </React.Fragment>
           <h4>Footer</h4>
-          <React.Fragment>
-            <span className="lab-playground__item">
-              <TextInput
-                id="avatarSrc"
-                label="avatarSrc"
-                value={avatarSrc}
-                onChange={this.handlePropChangeText}
-                required
-              />
-            </span>
-            <span className="lab-playground__item">
-              <TextInput
-                id="avatarAltText"
-                label="avatarAltText"
-                value={avatarAltText}
-                onChange={this.handlePropChangeText}
-                required
-              />
-            </span>
-            <span className="lab-playground__item">
-              <TextInput
-                id="avatarCaption"
-                label="avatarCaption"
-                value={avatarCaption}
-                onChange={this.handlePropChangeText}
-                required
-              />
-            </span>
-          </React.Fragment>
           <React.Fragment>
             <span className="lab-playground__item">
               <TextInput

--- a/playgrounds/NarrowSidebarPlayground.js
+++ b/playgrounds/NarrowSidebarPlayground.js
@@ -237,7 +237,7 @@ export default class NarrowSidebarPlayground extends React.Component {
               />
             </fieldset>
           </span>
-          <h4>Body</h4>
+          <h3>Body</h3>
           <React.Fragment>
             <span className="lab-playground__item">
               <TextInput
@@ -267,7 +267,7 @@ export default class NarrowSidebarPlayground extends React.Component {
               onClick={this.addNewItem}
             />
           </React.Fragment>
-          <h4>Footer</h4>
+          <h3>Footer</h3>
           <React.Fragment>
             <span className="lab-playground__item">
               <TextInput

--- a/playgrounds/NarrowSidebarPlayground.js
+++ b/playgrounds/NarrowSidebarPlayground.js
@@ -307,15 +307,15 @@ export default class NarrowSidebarPlayground extends React.Component {
                 required
               />
             </span>
-            <Button
-              text="Add item"
-              size="normal"
-              onClick={this.addNewItem}
-            />
             <OutlineButton
               text="Remove last item"
               size="normal"
               onClick={this.removeLastItem}
+            />
+            <Button
+              text="Add item"
+              size="normal"
+              onClick={this.addNewItem}
             />
           </React.Fragment>
           <h4>Footer</h4>
@@ -366,15 +366,15 @@ export default class NarrowSidebarPlayground extends React.Component {
                 required
               />
             </span>
-            <Button
-              text="Add footer button"
-              size="normal"
-              onClick={this.addNewFooterButton}
-            />
             <OutlineButton
               text="Remove last footer button"
               size="normal"
               onClick={this.removeLastFooterButton}
+            />
+            <Button
+              text="Add footer button"
+              size="normal"
+              onClick={this.addNewFooterButton}
             />
           </React.Fragment>
         </div>

--- a/playgrounds/RadioPlayground.js
+++ b/playgrounds/RadioPlayground.js
@@ -77,7 +77,6 @@ export default class RadioPlayground extends React.Component {
           </div>
 
           <div className="column lab-playground__configs">
-            <h3>Prop Settings</h3>
             <span className="lab-playground__item">
               <TextInput
                 label="Option 1 Label"

--- a/playgrounds/SystemMessagesPlayground.js
+++ b/playgrounds/SystemMessagesPlayground.js
@@ -91,8 +91,6 @@ export default class SystemMessagesPlayground extends React.Component {
         </div>
 
         <div className="column lab-playground__configs">
-          <h3>Prop Settings</h3>
-
           <span className="lab-playground__item">
             <fieldset>
               <legend>Variation</legend>

--- a/playgrounds/TagPlayground.js
+++ b/playgrounds/TagPlayground.js
@@ -168,8 +168,6 @@ export default class TagPlayground extends React.Component {
         </div>
 
         <div className="column lab-playground__configs">
-          <h3>Prop Settings</h3>
-
           <span className="lab-playground__item">
             <label htmlFor="currentComponent">
               Variation

--- a/playgrounds/TextInputPlayground.js
+++ b/playgrounds/TextInputPlayground.js
@@ -169,9 +169,7 @@ export default class TextInputPlayground extends React.Component {
         <div className="column lab-playground__component">
           {this.renderCurrentComponent()}
         </div>
-
         <div className="column lab-playground__configs">
-          <h3>Prop Settings</h3>
           <div className="lab-playground__item">
             <fieldset>
               <legend>Variation</legend>

--- a/playgrounds/assets.js
+++ b/playgrounds/assets.js
@@ -72,3 +72,9 @@ export const buttonSkinOptions = {
   OutlineButton: ["", "light", "dark"],
   TextButton: ["", "light", "dark"],
 };
+
+export const skinsWithBackground = [
+  "light",
+  "destructive-invert",
+  "confirmation-invert",
+];

--- a/playgrounds/scss/playgrounds.scss
+++ b/playgrounds/scss/playgrounds.scss
@@ -12,7 +12,7 @@
 .lab-playground__configs {
   border-left: 2px solid $mineral-10;
   padding: $spacing-6;
-  height: 100%;
+  height: auto;
 
   // Text Styles
   h3 {

--- a/playgrounds/scss/playgrounds.scss
+++ b/playgrounds/scss/playgrounds.scss
@@ -16,12 +16,6 @@
 
   // Text Styles
   h3 {
-    font-size: $font-size-7;
-    margin-top: 0;
-    margin-bottom: $spacing-3;
-  }
-
-  h4 { 
     margin: $spacing-2 0;
     font-size: $font-size-5;
     font-weight: $weight-semibold;

--- a/stories/Buttons.stories.mdx
+++ b/stories/Buttons.stories.mdx
@@ -53,7 +53,7 @@ import ButtonPlayground from "../playgrounds/ButtonPlayground";
         </div>
       </div>
     <h2>Interactive Demo</h2>
-      <p>This demo lets you preview the button component, its variations, and configuration options.</p>
+      <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
       <ButtonPlayground />
     <h2>Prop API</h2>
       <p>Go to <a href="/?path=/docs/getting-started-setup-confetti--page">Setup</a> for instructions on how to import the component.</p>

--- a/stories/Buttons.stories.mdx
+++ b/stories/Buttons.stories.mdx
@@ -53,7 +53,7 @@ import ButtonPlayground from "../playgrounds/ButtonPlayground";
         </div>
       </div>
     <h2>Interactive Demo</h2>
-      <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
+      <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
       <ButtonPlayground />
     <h2>Prop API</h2>
       <p>Go to <a href="/?path=/docs/getting-started-setup-confetti--page">Setup</a> for instructions on how to import the component.</p>

--- a/stories/Card.stories.mdx
+++ b/stories/Card.stories.mdx
@@ -55,7 +55,7 @@ import CardPlayground from '../playgrounds/CardPlayground';
       </div>
     </div>
     <h2>Interactive Demo</h2>
-    <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>   
+    <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>   
     <CardPlayground />
     <h2>Prop API docs</h2>
     <p>Here's the list of props based on the components' prop types definitions.</p>

--- a/stories/Card.stories.mdx
+++ b/stories/Card.stories.mdx
@@ -55,7 +55,7 @@ import CardPlayground from '../playgrounds/CardPlayground';
       </div>
     </div>
     <h2>Interactive Demo</h2>
-    <p>This demo lets you preview the card component, its variations, and configuration options.</p>   
+    <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>   
     <CardPlayground />
     <h2>Prop API docs</h2>
     <p>Here's the list of props based on the components' prop types definitions.</p>

--- a/stories/Checkbox.stories.mdx
+++ b/stories/Checkbox.stories.mdx
@@ -41,7 +41,7 @@ import CheckboxPlayground from '../playgrounds/CheckboxPlayground';
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
+  <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
   <CheckboxPlayground />
 
   <h2>Acessibility</h2>

--- a/stories/Checkbox.stories.mdx
+++ b/stories/Checkbox.stories.mdx
@@ -41,7 +41,7 @@ import CheckboxPlayground from '../playgrounds/CheckboxPlayground';
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo lets you preview the checkbox component, its variations, and configuration options.</p>
+  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
   <CheckboxPlayground />
 
   <h2>Acessibility</h2>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -80,7 +80,7 @@ import DialogPlayground from "../playgrounds/DialogPlayground";
           </div>
       </div>
     <h2>Interactive demo</h2>
-    <p>This demo lets you preview the component, its variations, and configuration options.</p>
+    <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
     <DialogPlayground />
     <h2>Prop API</h2>
     <p>Go to <a href="/?path=/docs/getting-started-setup-confetti--page">Setup</a> for instructions on how to import the component.</p>

--- a/stories/Dialog.stories.mdx
+++ b/stories/Dialog.stories.mdx
@@ -80,7 +80,7 @@ import DialogPlayground from "../playgrounds/DialogPlayground";
           </div>
       </div>
     <h2>Interactive demo</h2>
-    <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
+    <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
     <DialogPlayground />
     <h2>Prop API</h2>
     <p>Go to <a href="/?path=/docs/getting-started-setup-confetti--page">Setup</a> for instructions on how to import the component.</p>

--- a/stories/NarrowSidebar.stories.mdx
+++ b/stories/NarrowSidebar.stories.mdx
@@ -63,7 +63,7 @@ import NarrowSidebarPlayground from '../playgrounds/NarrowSidebarPlayground';
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
+  <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
 
   <NarrowSidebarPlayground />
 

--- a/stories/NarrowSidebar.stories.mdx
+++ b/stories/NarrowSidebar.stories.mdx
@@ -63,7 +63,7 @@ import NarrowSidebarPlayground from '../playgrounds/NarrowSidebarPlayground';
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options.</p>
+  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
 
   <NarrowSidebarPlayground />
 

--- a/stories/Radio.stories.mdx
+++ b/stories/Radio.stories.mdx
@@ -41,7 +41,7 @@ import RadioPlayground from '../playgrounds/RadioPlayground';
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
+  <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
   <RadioPlayground />
 
   <h2>Accessibility</h2>

--- a/stories/Radio.stories.mdx
+++ b/stories/Radio.stories.mdx
@@ -41,7 +41,7 @@ import RadioPlayground from '../playgrounds/RadioPlayground';
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo lets you preview the component, its variations, and configuration options.</p>
+  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
   <RadioPlayground />
 
   <h2>Accessibility</h2>

--- a/stories/SystemMessages.stories.mdx
+++ b/stories/SystemMessages.stories.mdx
@@ -76,7 +76,7 @@ import SystemMessagesPlayground from "../playgrounds/SystemMessagesPlayground.js
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
+  <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
   <SystemMessagesPlayground />
 
   <h2>Prop API</h2>

--- a/stories/SystemMessages.stories.mdx
+++ b/stories/SystemMessages.stories.mdx
@@ -76,7 +76,7 @@ import SystemMessagesPlayground from "../playgrounds/SystemMessagesPlayground.js
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options.</p>
+  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below</p>
   <SystemMessagesPlayground />
 
   <h2>Prop API</h2>

--- a/stories/Tag.stories.mdx
+++ b/stories/Tag.stories.mdx
@@ -67,7 +67,7 @@ import { thumbSrcOptions, iconOptions } from "../playgrounds/assets";
       </div>
     </div>
     <h2>Interactive demo</h2>
-    <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
+    <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
     <TagPlayground />
     <h2>Prop API</h2>
     <p>Go to <a href="/?path=/docs/getting-started-setup-confetti--page">Setup</a> for instructions on how to import the component.</p>

--- a/stories/Tag.stories.mdx
+++ b/stories/Tag.stories.mdx
@@ -67,7 +67,7 @@ import { thumbSrcOptions, iconOptions } from "../playgrounds/assets";
       </div>
     </div>
     <h2>Interactive demo</h2>
-    <p>This demo lets you preview the component, its variations, and configuration options.</p>
+    <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
     <TagPlayground />
     <h2>Prop API</h2>
     <p>Go to <a href="/?path=/docs/getting-started-setup-confetti--page">Setup</a> for instructions on how to import the component.</p>

--- a/stories/TextInput.stories.mdx
+++ b/stories/TextInput.stories.mdx
@@ -69,7 +69,7 @@ import TextInputPlayground from '../playgrounds/TextInputPlayground';
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
+  <p>This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
   <TextInputPlayground />
 
   <h2>Prop API</h2>

--- a/stories/TextInput.stories.mdx
+++ b/stories/TextInput.stories.mdx
@@ -69,7 +69,7 @@ import TextInputPlayground from '../playgrounds/TextInputPlayground';
   </div>
 
   <h2>Interactive demo</h2>
-  <p>This demo lets you preview the component, its variations, and configuration options.</p>
+  <p>This demo let you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.</p>
   <TextInputPlayground />
 
   <h2>Prop API</h2>


### PR DESCRIPTION
**Link to task:** https://labcodes.atlassian.net/browse/CSYS-191

**Staging app:** https://playground-imrpovements-qa--labstorybook-master.netlify.app/

**How to test:**
- Check if buttons with light, destructive-invert, or confirmation-invert skins display a dar background
- Check if the border dividing the playground has the container's full height
- Check if the "Interactive Demo" section displays the description: `This demo lets you preview the component, its variations, and configuration options. Not all props are available as controls, for more information check the Prop API below.`
- Check if Narrow Sidebar and Card's playgrounds display a consecutive header order

**Description of your solution:**
- Added a background to some button's skin so it's possible to see the white background
- Adjusted config panel style so that the border goes till the end of the container
- Removed `Prop Settings` title in playground controls panel to avoid confusion between controls and props capabilities
- Replaced `<h4>` for `<h3>` in playground controls and adjusted its style (available in Narrow Sidebar and Cards)
- Removed controls that didn't add visual changes in Narrow Sidebar controls
- Improved `Interactive Demo` section description to avoid confusion between controls and props values
